### PR TITLE
Add unmarshalling of Links

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -7,6 +7,7 @@ const (
 	annotationClientID  = "client-id"
 	annotationAttribute = "attr"
 	annotationRelation  = "relation"
+	annotationLinks     = "links"
 	annotationOmitEmpty = "omitempty"
 	annotationISO8601   = "iso8601"
 	annotationRFC3339   = "rfc3339"

--- a/models_test.go
+++ b/models_test.go
@@ -56,11 +56,16 @@ type Post struct {
 }
 
 type Comment struct {
-	ID       int    `jsonapi:"primary,comments"`
-	ClientID string `jsonapi:"client-id"`
-	PostID   int    `jsonapi:"attr,post_id"`
-	Body     string `jsonapi:"attr,body"`
-	Links    *Links `jsonapi:"links,omitempty"`
+	ID       int                 `jsonapi:"primary,comments"`
+	ClientID string              `jsonapi:"client-id"`
+	PostID   int                 `jsonapi:"attr,post_id"`
+	Body     string              `jsonapi:"attr,body"`
+	Links    *Links              `jsonapi:"links,omitempty"`
+	Relation *SingleRelationLink `jsonapi:"relation,single-relation-link"`
+}
+
+type SingleRelationLink struct {
+	Links *Links `jsonapi:"links,omitempty"`
 }
 
 type Book struct {

--- a/models_test.go
+++ b/models_test.go
@@ -60,7 +60,7 @@ type Comment struct {
 	ClientID    string       `jsonapi:"client-id"`
 	PostID      int          `jsonapi:"attr,post_id"`
 	Body        string       `jsonapi:"attr,body"`
-	Impressions *Impressions `jsonapi:"relation,single-relation-link"`
+	Impressions *Impressions `jsonapi:"relation,impressions"`
 	URL         *Links       `jsonapi:"links,omitempty"`
 }
 

--- a/models_test.go
+++ b/models_test.go
@@ -56,16 +56,16 @@ type Post struct {
 }
 
 type Comment struct {
-	ID       int                 `jsonapi:"primary,comments"`
-	ClientID string              `jsonapi:"client-id"`
-	PostID   int                 `jsonapi:"attr,post_id"`
-	Body     string              `jsonapi:"attr,body"`
-	Links    *Links              `jsonapi:"links,omitempty"`
-	Relation *SingleRelationLink `jsonapi:"relation,single-relation-link"`
+	ID          int          `jsonapi:"primary,comments"`
+	ClientID    string       `jsonapi:"client-id"`
+	PostID      int          `jsonapi:"attr,post_id"`
+	Body        string       `jsonapi:"attr,body"`
+	Impressions *Impressions `jsonapi:"relation,single-relation-link"`
+	URL         *Links       `jsonapi:"links,omitempty"`
 }
 
-type SingleRelationLink struct {
-	Links *Links `jsonapi:"links,omitempty"`
+type Impressions struct {
+	URL *Links `jsonapi:"links,omitempty"`
 }
 
 type Book struct {

--- a/models_test.go
+++ b/models_test.go
@@ -60,6 +60,7 @@ type Comment struct {
 	ClientID string `jsonapi:"client-id"`
 	PostID   int    `jsonapi:"attr,post_id"`
 	Body     string `jsonapi:"attr,body"`
+	Links    *Links `jsonapi:"links,omitempty"`
 }
 
 type Book struct {

--- a/request.go
+++ b/request.go
@@ -314,8 +314,8 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 								break
 							}
 
-							assignedValue = true
 							assign(fieldValue, value)
+							assignedValue = true
 						}
 					}
 					if assignedValue {

--- a/request.go
+++ b/request.go
@@ -274,6 +274,7 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 				json.NewDecoder(buf).Decode(relationship)
 
 				data := relationship.Data
+				links := relationship.Links
 				models := reflect.New(fieldValue.Type()).Elem()
 
 				for _, n := range data {
@@ -289,6 +290,31 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 					}
 
 					models = reflect.Append(models, m)
+				}
+
+				if links != nil {
+					linkModel := reflect.New(fieldValue.Type().Elem().Elem())
+					linkModelValue := linkModel.Elem()
+					linkModelType := linkModelValue.Type()
+					for i := 0; i < linkModelValue.NumField(); i++ {
+						fieldType := linkModelType.Field(i)
+						tag := fieldType.Tag.Get("jsonapi")
+						if tag == "" {
+							continue
+						}
+						fieldValue := linkModelValue.Field(i)
+						args := strings.Split(tag, ",")
+						annotation := args[0]
+						if annotation == annotationLinks {
+							value, err := unmarshalAttribute(*links, args, fieldType, fieldValue)
+							if err != nil {
+								er = err
+								break
+							}
+							assign(fieldValue, value)
+						}
+					}
+					models = reflect.Append(models, linkModel)
 				}
 
 				fieldValue.Set(models)
@@ -326,6 +352,21 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 				fieldValue.Set(m)
 
 			}
+
+		} else if annotation == annotationLinks {
+			links := data.Links
+			if links == nil {
+				continue
+			}
+
+			structField := fieldType
+			value, err := unmarshalAttribute(*links, args, structField, fieldValue)
+			if err != nil {
+				er = err
+				break
+			}
+
+			assign(fieldValue, value)
 
 		} else {
 			er = fmt.Errorf(unsupportedStructTagMsg, annotation)
@@ -409,6 +450,11 @@ func unmarshalAttribute(
 		return
 	}
 
+	if fieldValue.Type() == reflect.TypeOf(&Links{}) {
+		value, err = handleLinks(attribute, args, fieldValue)
+		return
+	}
+
 	// Handle field of type struct
 	if fieldValue.Type().Kind() == reflect.Struct {
 		value, err = handleStruct(attribute, fieldValue)
@@ -461,6 +507,25 @@ func handleMapStringSlice(attribute interface{}, fieldValue reflect.Value) (refl
 			sliceValues = append(sliceValues, v.(string))
 		}
 		values[key] = sliceValues
+	}
+
+	return reflect.ValueOf(values), nil
+}
+
+func handleLinks(attribute interface{}, args []string, fieldValue reflect.Value) (reflect.Value, error) {
+	b, err := json.Marshal(attribute)
+	if err != nil {
+		return reflect.Value{}, err
+	}
+	var v interface{}
+	err = json.Unmarshal(b, &v)
+	if err != nil {
+		return reflect.Value{}, err
+	}
+
+	var values = map[string]interface{}{}
+	for k, v := range v.(map[string]interface{}) {
+		values[k] = v.(interface{})
 	}
 
 	return reflect.ValueOf(values), nil

--- a/request.go
+++ b/request.go
@@ -293,9 +293,11 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 				}
 
 				if links != nil {
+					var assignedValue bool
 					linkModel := reflect.New(fieldValue.Type().Elem().Elem())
 					linkModelValue := linkModel.Elem()
 					linkModelType := linkModelValue.Type()
+
 					for i := 0; i < linkModelValue.NumField(); i++ {
 						fieldType := linkModelType.Field(i)
 						tag := fieldType.Tag.Get("jsonapi")
@@ -311,10 +313,14 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 								er = err
 								break
 							}
+
+							assignedValue = true
 							assign(fieldValue, value)
 						}
 					}
-					models = reflect.Append(models, linkModel)
+					if assignedValue {
+						models = reflect.Append(models, linkModel)
+					}
 				}
 
 				fieldValue.Set(models)

--- a/request.go
+++ b/request.go
@@ -341,13 +341,23 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 					relationship can have a data node set to null (e.g. to disassociate the relationship)
 					so unmarshal and set fieldValue only if data obj is not null
 				*/
-				if relationship.Data == nil {
+
+				if relationship.Data == nil && relationship.Links == nil {
 					continue
+				}
+
+				node := &Node{}
+				if relationship.Data != nil {
+					node = relationship.Data
+				}
+
+				if relationship.Links != nil {
+					node.Links = relationship.Links
 				}
 
 				m := reflect.New(fieldValue.Type().Elem())
 				if err := unmarshalNode(
-					fullNode(relationship.Data, included),
+					fullNode(node, included),
 					m,
 					included,
 				); err != nil {
@@ -356,7 +366,6 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 				}
 
 				fieldValue.Set(m)
-
 			}
 
 		} else if annotation == annotationLinks {

--- a/request_test.go
+++ b/request_test.go
@@ -772,6 +772,58 @@ func TestUnmarshalManyPayload(t *testing.T) {
 	}
 }
 
+func TestOnePayload_WithRelationLinks(t *testing.T) {
+	selfLink := "http://example.com/articles/1/relationships/author"
+	relatedLink := "http://example.com/articles/1/author"
+	sample := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "posts",
+			"id":   "1",
+			"attributes": map[string]interface{}{
+				"body":  "First",
+				"title": "Post",
+			},
+			"relationships": map[string]interface{}{
+				"comments": map[string]interface{}{
+					"links": map[string]string{
+						"self":    selfLink,
+						"related": relatedLink,
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := bytes.NewReader(data)
+
+	out := new(Post)
+
+	if err := UnmarshalPayload(in, out); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(out.Comments) == 0 {
+		t.Fatal("Was expecting non-empty Comments")
+	}
+
+	if out.Comments[0].Links == nil {
+		t.Fatal("Was expecting a non nil ptr Link field")
+	}
+
+	links := *out.Comments[0].Links
+	if links["self"] != selfLink {
+		t.Fatalf("Was expecting self Link to equal %s, but got %s", selfLink, links["self"])
+	}
+
+	if links["related"] != relatedLink {
+		t.Fatalf("Was expecting related Link to equal %s, but got %s", relatedLink, links["related"])
+	}
+}
+
 func TestManyPayload_withLinks(t *testing.T) {
 	firstPageURL := "http://somesite.com/movies?page[limit]=50&page[offset]=50"
 	prevPageURL := "http://somesite.com/movies?page[limit]=50&page[offset]=0"

--- a/request_test.go
+++ b/request_test.go
@@ -868,6 +868,54 @@ func TestOnePayload_WithLinks(t *testing.T) {
 	}
 }
 
+func TestOnePayload_RelationshipLinks(t *testing.T) {
+	selfLink := "http://example.com/articles/1/relationships/author"
+	relatedLink := "http://example.com/articles/1/author"
+	sample := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "comments",
+			"id":   "1",
+			"attributes": map[string]interface{}{
+				"body":  "First",
+				"title": "Post",
+			},
+			"relationships": map[string]interface{}{
+				"single-relation-link": map[string]interface{}{
+					"links": map[string]string{
+						"self":    selfLink,
+						"related": relatedLink,
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := bytes.NewReader(data)
+
+	out := new(Comment)
+
+	if err := UnmarshalPayload(in, out); err != nil {
+		t.Fatal(err)
+	}
+
+	if out.Relation == nil {
+		t.Fatal("Was expecting a non nil ptr Link field")
+	}
+
+	links := *out.Relation.Links
+	if links["self"] != selfLink {
+		t.Fatalf("Was expecting self Link to equal %s, but got %s", selfLink, links["self"])
+	}
+
+	if links["related"] != relatedLink {
+		t.Fatalf("Was expecting related Link to equal %s, but got %s", relatedLink, links["related"])
+	}
+}
+
 func TestManyPayload_withLinks(t *testing.T) {
 	firstPageURL := "http://somesite.com/movies?page[limit]=50&page[offset]=50"
 	prevPageURL := "http://somesite.com/movies?page[limit]=50&page[offset]=0"

--- a/request_test.go
+++ b/request_test.go
@@ -1201,9 +1201,6 @@ func testModel() *Blog {
 					{
 						ID:   2,
 						Body: "bar",
-						Links: &Links{
-							"self": "http://example.com/articles/1/relationships/author",
-						},
 					},
 				},
 				LatestComment: &Comment{

--- a/request_test.go
+++ b/request_test.go
@@ -1157,6 +1157,9 @@ func testModel() *Blog {
 					{
 						ID:   2,
 						Body: "bar",
+						Links: &Links{
+							"self": "http://example.com/articles/1/relationships/author",
+						},
 					},
 				},
 				LatestComment: &Comment{

--- a/request_test.go
+++ b/request_test.go
@@ -824,6 +824,50 @@ func TestOnePayload_WithRelationLinks(t *testing.T) {
 	}
 }
 
+func TestOnePayload_WithLinks(t *testing.T) {
+	selfLink := "http://example.com/articles/1/relationships/author"
+	relatedLink := "http://example.com/articles/1/author"
+	sample := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "comments",
+			"id":   "1",
+			"attributes": map[string]interface{}{
+				"body":  "First",
+				"title": "Post",
+			},
+			"links": map[string]string{
+				"self":    selfLink,
+				"related": relatedLink,
+			},
+		},
+	}
+
+	data, err := json.Marshal(sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := bytes.NewReader(data)
+
+	out := new(Comment)
+
+	if err := UnmarshalPayload(in, out); err != nil {
+		t.Fatal(err)
+	}
+
+	if out.Links == nil {
+		t.Fatal("Was expecting a non nil ptr Link field")
+	}
+
+	links := *out.Links
+	if links["self"] != selfLink {
+		t.Fatalf("Was expecting self Link to equal %s, but got %s", selfLink, links["self"])
+	}
+
+	if links["related"] != relatedLink {
+		t.Fatalf("Was expecting related Link to equal %s, but got %s", relatedLink, links["related"])
+	}
+}
+
 func TestManyPayload_withLinks(t *testing.T) {
 	firstPageURL := "http://somesite.com/movies?page[limit]=50&page[offset]=50"
 	prevPageURL := "http://somesite.com/movies?page[limit]=50&page[offset]=0"

--- a/request_test.go
+++ b/request_test.go
@@ -880,7 +880,7 @@ func TestOnePayload_RelationshipLinks(t *testing.T) {
 				"title": "Post",
 			},
 			"relationships": map[string]interface{}{
-				"single-relation-link": map[string]interface{}{
+				"impressions": map[string]interface{}{
 					"links": map[string]string{
 						"self":    selfLink,
 						"related": relatedLink,

--- a/request_test.go
+++ b/request_test.go
@@ -810,11 +810,11 @@ func TestOnePayload_WithRelationLinks(t *testing.T) {
 		t.Fatal("Was expecting non-empty Comments")
 	}
 
-	if out.Comments[0].Links == nil {
+	if out.Comments[0].URL == nil {
 		t.Fatal("Was expecting a non nil ptr Link field")
 	}
 
-	links := *out.Comments[0].Links
+	links := *out.Comments[0].URL
 	if links["self"] != selfLink {
 		t.Fatalf("Was expecting self Link to equal %s, but got %s", selfLink, links["self"])
 	}
@@ -854,11 +854,11 @@ func TestOnePayload_WithLinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if out.Links == nil {
+	if out.URL == nil {
 		t.Fatal("Was expecting a non nil ptr Link field")
 	}
 
-	links := *out.Links
+	links := *out.URL
 	if links["self"] != selfLink {
 		t.Fatalf("Was expecting self Link to equal %s, but got %s", selfLink, links["self"])
 	}
@@ -902,11 +902,11 @@ func TestOnePayload_RelationshipLinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if out.Relation == nil {
+	if out.Impressions == nil {
 		t.Fatal("Was expecting a non nil ptr Link field")
 	}
 
-	links := *out.Relation.Links
+	links := *out.Impressions.URL
 	if links["self"] != selfLink {
 		t.Fatalf("Was expecting self Link to equal %s, but got %s", selfLink, links["self"])
 	}

--- a/response.go
+++ b/response.go
@@ -441,6 +441,10 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 					}
 				}
 			}
+		} else if annotation == annotationLinks {
+			// Handling the `jsonapi:"links"` annotation without
+			// doing anything as the Links are handled below via the
+			// Linkable interface
 
 		} else {
 			er = ErrBadJSONAPIStructTag

--- a/response.go
+++ b/response.go
@@ -442,9 +442,12 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 				}
 			}
 		} else if annotation == annotationLinks {
-			// Handling the `jsonapi:"links"` annotation without
-			// doing anything as the Links are handled below via the
-			// Linkable interface
+			// This is for marshalling.
+			// This is left blank intentionally as the handling
+			// of `jsonapi:"links"` is done below via the
+			// Linkable interface.
+			// And the logic for Marshalling links should be done
+			// via that interface.
 
 		} else {
 			er = ErrBadJSONAPIStructTag


### PR DESCRIPTION
## Description

According to the [JSON:API Spec](https://jsonapi.org/format/#document-resource-object-links), an object may contain a `self` link:

```
{
  "type": "articles",
  "id": "1",
  "attributes": {
    "title": "Rails is Omakase"
  },
  "links": {
    "self": "http://example.com/articles/1"
  }
}
```

We did not have the ability to unmarshal an object that had the `links` annotation to it. This PR adds the ability to unmarshal it. 

### Tests

```
$ go test -v ./...
...
PASS
ok      _/Users/omarismail/work/hashi-jsonapi/examples  0.198s
```