### PR TITLE
Handle Marshaling Structs and Slices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,5 @@
 module github.com/hashicorp/jsonapi
+
+go 1.16
+
+require github.com/mitchellh/mapstructure v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
+github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=

--- a/models_test.go
+++ b/models_test.go
@@ -51,8 +51,15 @@ type Post struct {
 	ClientID      string     `jsonapi:"client-id"`
 	Title         string     `jsonapi:"attr,title"`
 	Body          string     `jsonapi:"attr,body"`
+	Meta          *PostMeta  `jsonapi:"attr,meta"`
 	Comments      []*Comment `jsonapi:"relation,comments"`
 	LatestComment *Comment   `jsonapi:"relation,latest_comment"`
+}
+
+type PostMeta struct {
+	Author string `jsonapi:"attr,author,omitempty"`
+	Age    int    `jsonapi:"attr,age,omitempty"`
+	Seen   bool   `jsonapi:"attr,seen,omitempty"`
 }
 
 type Comment struct {

--- a/models_test.go
+++ b/models_test.go
@@ -71,7 +71,9 @@ type Comment struct {
 }
 
 type Likes struct {
-	Count int `jsonapi:"attr,count"`
+	Count      int    `jsonapi:"attr,count"`
+	IsFavorite bool   `jsonapi:"attr,is-favorite"`
+	Email      string `jsonapi:"attr,email,omitempty"`
 }
 
 type Impressions struct {

--- a/models_test.go
+++ b/models_test.go
@@ -67,8 +67,13 @@ type Comment struct {
 	ClientID    string       `jsonapi:"client-id"`
 	PostID      int          `jsonapi:"attr,post_id"`
 	Body        string       `jsonapi:"attr,body"`
+	Likes       []*Likes     `jsonapi:"attr,likes"`
 	Impressions *Impressions `jsonapi:"relation,impressions"`
 	URL         *Links       `jsonapi:"links,omitempty"`
+}
+
+type Likes struct {
+	Count int `jsonapi:"attr,count"`
 }
 
 type Impressions struct {

--- a/models_test.go
+++ b/models_test.go
@@ -65,7 +65,7 @@ type Comment struct {
 	ClientID    string       `jsonapi:"client-id"`
 	PostID      int          `jsonapi:"attr,post_id"`
 	Body        string       `jsonapi:"attr,body"`
-	Likes       []*Likes     `jsonapi:"attr,likes"`
+	Likes       []Likes      `jsonapi:"attr,likes"`
 	Impressions *Impressions `jsonapi:"relation,impressions"`
 	URL         *Links       `jsonapi:"links,omitempty"`
 }

--- a/response.go
+++ b/response.go
@@ -353,7 +353,31 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 					}
 					node.Attributes[args[1]] = val
 				}
-				//node.Attributes[args[1]] = fieldValue.Interface()
+
+			} else if fieldValue.Kind() == reflect.Slice {
+				var omitEmpty bool
+				isSlice := fieldValue.Type().Kind() == reflect.Slice
+
+				if omitEmpty &&
+					(isSlice && fieldValue.Len() < 1 ||
+						(!isSlice && fieldValue.IsNil())) {
+					continue
+				}
+
+				fmt.Println("OMAR")
+				fmt.Println(isSlice)
+
+				data, err := visitModelNodeRelationships(
+					fieldValue,
+					included,
+					sideload,
+				)
+				if err != nil {
+					er = err
+					break
+				}
+				fmt.Println(data.Data)
+
 			} else {
 				// Dealing with a fieldValue that is not a time
 				emptyValue := reflect.Zero(fieldValue.Type())

--- a/response.go
+++ b/response.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"io"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 var (

--- a/response.go
+++ b/response.go
@@ -651,17 +651,23 @@ func marshalStruct(model interface{}) (map[string]interface{}, error) {
 		}
 
 		annotation := args[0]
+		var omitEmpty bool
+
+		//add support for 'omitempty' struct tag for marshaling as absent
+		if len(args) > 2 {
+			omitEmpty = args[2] == annotationOmitEmpty
+		}
+
 		// we should only process attrs
 		if annotation != annotationAttribute {
 			continue
 		}
 
-		strAttr, ok := fieldValue.Interface().(string)
-		if ok {
-			attributes[args[1]] = strAttr
-		} else {
-			attributes[args[1]] = fieldValue.Interface()
+		if omitEmpty && fieldValue.IsZero() {
+			continue
 		}
+
+		attributes[args[1]] = fieldValue.Interface()
 	}
 
 	return attributes, nil

--- a/response.go
+++ b/response.go
@@ -445,10 +445,6 @@ func marshalAttribute(node *Node, fieldValue reflect.Value, args []string) error
 		}
 	}
 
-	if node.Attributes == nil {
-		node.Attributes = make(map[string]interface{})
-	}
-
 	if fieldValue.Type() == reflect.TypeOf(time.Time{}) {
 		err = marshalHandleTime(node, fieldValue, args, iso8601, rfc3339, omitEmpty)
 	} else if fieldValue.Type() == reflect.TypeOf(new(time.Time)) {

--- a/response.go
+++ b/response.go
@@ -300,15 +300,6 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 				node.Attributes = make(map[string]interface{})
 			}
 
-			//empty, err := marshalAttribute(node, fieldValue, args, omitEmpty)
-			//if err != nil {
-			//	er = err
-			//	break
-			//}
-			//if empty {
-			//	continue
-			//}
-
 			if fieldValue.Type() == reflect.TypeOf(time.Time{}) {
 				t := fieldValue.Interface().(time.Time)
 
@@ -502,78 +493,6 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 	}
 
 	return node, nil
-}
-
-func marshalAttribute(node *Node, fieldValue reflect.Value, args []string, omitEmpty bool) (empty bool, err error) {
-
-	if fieldValue.Type() == reflect.TypeOf(time.Time{}) {
-		return marshalTime(node, fieldValue, args, omitEmpty)
-	} else if fieldValue.Type() == reflect.TypeOf(new(time.Time)) {
-		return marshalNewTime(node, fieldValue, args, omitEmpty)
-	}
-
-	return false, nil
-}
-
-func marshalTime(node *Node, fieldValue reflect.Value, args []string, omitEmpty bool) (empty bool, err error) {
-	t := fieldValue.Interface().(time.Time)
-
-	if t.IsZero() {
-		return true, nil
-	}
-
-	var iso8601 bool
-	if len(args) > 2 {
-		for _, arg := range args[2:] {
-			switch arg {
-			case annotationISO8601:
-				iso8601 = true
-			}
-		}
-	}
-
-	if iso8601 {
-		node.Attributes[args[1]] = t.UTC().Format(iso8601TimeFormat)
-	} else {
-		node.Attributes[args[1]] = t.Unix()
-	}
-
-	return false, nil
-}
-
-func marshalNewTime(node *Node, fieldValue reflect.Value, args []string, omitEmpty bool) (empty bool, err error) {
-	var iso8601 bool
-	if len(args) > 2 {
-		for _, arg := range args[2:] {
-			switch arg {
-			case annotationISO8601:
-				iso8601 = true
-			}
-		}
-	}
-
-	// A time pointer may be nil
-	if fieldValue.IsNil() {
-		if omitEmpty {
-			return true, nil
-		}
-
-		node.Attributes[args[1]] = nil
-	} else {
-		tm := fieldValue.Interface().(*time.Time)
-
-		if tm.IsZero() && omitEmpty {
-			return true, nil
-		}
-
-		if iso8601 {
-			node.Attributes[args[1]] = tm.UTC().Format(iso8601TimeFormat)
-		} else {
-			node.Attributes[args[1]] = tm.Unix()
-		}
-	}
-
-	return false, nil
 }
 
 func toShallowNode(node *Node) *Node {

--- a/response_test.go
+++ b/response_test.go
@@ -831,10 +831,13 @@ func TestMarshalPayloadWithoutIncluded_NestedSlice(t *testing.T) {
 		Body:     "Bar",
 		Likes: []Likes{
 			Likes{
-				Count: 42,
+				Count:      42,
+				IsFavorite: true,
+				Email:      "json@hashicorp.com",
 			},
 			Likes{
-				Count: 42,
+				Count:      42,
+				IsFavorite: false,
 			},
 		},
 	}
@@ -844,7 +847,7 @@ func TestMarshalPayloadWithoutIncluded_NestedSlice(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedBody := `{"data":{"type":"comments","id":"1","client-id":"123e4567-e89b-12d3-a456-426655440000","attributes":{"body":"Bar","likes":[{"count":42},{"count":42}],"post_id":0},"relationships":{"impressions":{"data":null}}}}
+	expectedBody := `{"data":{"type":"comments","id":"1","client-id":"123e4567-e89b-12d3-a456-426655440000","attributes":{"body":"Bar","likes":[{"count":42,"email":"json@hashicorp.com","is-favorite":true},{"count":42,"is-favorite":false}],"post_id":0},"relationships":{"impressions":{"data":null}}}}
 `
 	if expectedBody != out.String() {
 		t.Fatal("Marshalled body not expected")

--- a/response_test.go
+++ b/response_test.go
@@ -3,7 +3,6 @@ package jsonapi
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -280,10 +279,10 @@ func TestWithOmitsEmptyAnnotationOnAttribute(t *testing.T) {
 }
 
 func TestMarshalIDPtr(t *testing.T) {
-	id, maik, model := "123e4567-e89b-12d3-a456-426655440000", "Ford", "Mustang"
+	id, make, model := "123e4567-e89b-12d3-a456-426655440000", "Ford", "Mustang"
 	car := &Car{
 		ID:    &id,
-		Make:  &maik,
+		Make:  &make,
 		Model: &model,
 	}
 
@@ -756,7 +755,12 @@ func TestMarshalPayloadWithoutIncluded_NestedStruct(t *testing.T) {
 	if err := MarshalPayloadWithoutIncluded(out, data); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(out.String())
+
+	expectedBody := `{"data":{"type":"posts","id":"1","client-id":"123e4567-e89b-12d3-a456-426655440000","attributes":{"blog_id":2,"body":"Bar","meta":{"type":"","attributes":{"age":42,"author":"bob","seen":true}},"title":"Foo"},"relationships":{"comments":{"data":[]},"latest_comment":{"data":null}},"links":{"comments":{"href":"https://example.com/api/blogs/0/comments","meta":{"counts":{"comments":20,"likes":4}}},"self":"https://example.com/api/blogs/0"},"meta":{"detail":"extra details regarding the blog"}}}
+`
+	if expectedBody != out.String() {
+		t.Fatal("Marshalled body not expected")
+	}
 
 	resp := new(OnePayload)
 	if err := json.NewDecoder(out).Decode(resp); err != nil {

--- a/response_test.go
+++ b/response_test.go
@@ -829,12 +829,12 @@ func TestMarshalPayloadWithoutIncluded_NestedSlice(t *testing.T) {
 		ID:       1,
 		ClientID: "123e4567-e89b-12d3-a456-426655440000",
 		Body:     "Bar",
-		Likes: []*Likes{
-			&Likes{
-				Count: 1,
+		Likes: []Likes{
+			Likes{
+				Count: 42,
 			},
-			&Likes{
-				Count: 2,
+			Likes{
+				Count: 42,
 			},
 		},
 	}
@@ -843,9 +843,12 @@ func TestMarshalPayloadWithoutIncluded_NestedSlice(t *testing.T) {
 	if err := MarshalPayloadWithoutIncluded(out, data); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(out.String())
 
-	//if expectedBody != out.String() { t.Fatal("Marshalled body not expected") }
+	expectedBody := `{"data":{"type":"comments","id":"1","client-id":"123e4567-e89b-12d3-a456-426655440000","attributes":{"body":"Bar","likes":[{"count":42},{"count":42}],"post_id":0},"relationships":{"impressions":{"data":null}}}}
+`
+	if expectedBody != out.String() {
+		t.Fatal("Marshalled body not expected")
+	}
 
 	resp := new(OnePayload)
 	if err := json.NewDecoder(out).Decode(resp); err != nil {

--- a/response_test.go
+++ b/response_test.go
@@ -812,7 +812,7 @@ func TestMarshalPayloadWithoutIncluded_NestedStruct(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedBody := `{"data":{"type":"posts","id":"1","client-id":"123e4567-e89b-12d3-a456-426655440000","attributes":{"blog_id":2,"body":"Bar","meta":{"type":"","attributes":{"age":42,"author":"bob","seen":true}},"title":"Foo"},"relationships":{"comments":{"data":[]},"latest_comment":{"data":null}},"links":{"comments":{"href":"https://example.com/api/blogs/0/comments","meta":{"counts":{"comments":20,"likes":4}}},"self":"https://example.com/api/blogs/0"},"meta":{"detail":"extra details regarding the blog"}}}
+	expectedBody := `{"data":{"type":"posts","id":"1","client-id":"123e4567-e89b-12d3-a456-426655440000","attributes":{"blog_id":2,"body":"Bar","meta":{"age":42,"author":"bob","seen":true},"title":"Foo"},"relationships":{"comments":{"data":[]},"latest_comment":{"data":null}},"links":{"comments":{"href":"https://example.com/api/blogs/0/comments","meta":{"counts":{"comments":20,"likes":4}}},"self":"https://example.com/api/blogs/0"},"meta":{"detail":"extra details regarding the blog"}}}
 `
 	if expectedBody != out.String() {
 		t.Fatal("Marshalled body not expected")

--- a/response_test.go
+++ b/response_test.go
@@ -3,6 +3,7 @@ package jsonapi
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -279,10 +280,10 @@ func TestWithOmitsEmptyAnnotationOnAttribute(t *testing.T) {
 }
 
 func TestMarshalIDPtr(t *testing.T) {
-	id, make, model := "123e4567-e89b-12d3-a456-426655440000", "Ford", "Mustang"
+	id, maik, model := "123e4567-e89b-12d3-a456-426655440000", "Ford", "Mustang"
 	car := &Car{
 		ID:    &id,
-		Make:  &make,
+		Make:  &maik,
 		Model: &model,
 	}
 
@@ -734,6 +735,32 @@ func TestMarshalPayloadWithoutIncluded(t *testing.T) {
 
 	if resp.Included != nil {
 		t.Fatalf("Encoding json response did not omit included")
+	}
+}
+
+func TestMarshalPayloadWithoutIncluded_NestedStruct(t *testing.T) {
+	data := &Post{
+		ID:       1,
+		BlogID:   2,
+		ClientID: "123e4567-e89b-12d3-a456-426655440000",
+		Title:    "Foo",
+		Body:     "Bar",
+		Meta: &PostMeta{
+			Author: "bob",
+			Age:    42,
+			Seen:   true,
+		},
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayloadWithoutIncluded(out, data); err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(out.String())
+
+	resp := new(OnePayload)
+	if err := json.NewDecoder(out).Decode(resp); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/response_test.go
+++ b/response_test.go
@@ -3,6 +3,7 @@ package jsonapi
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -761,6 +762,35 @@ func TestMarshalPayloadWithoutIncluded_NestedStruct(t *testing.T) {
 	if expectedBody != out.String() {
 		t.Fatal("Marshalled body not expected")
 	}
+
+	resp := new(OnePayload)
+	if err := json.NewDecoder(out).Decode(resp); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMarshalPayloadWithoutIncluded_NestedSlice(t *testing.T) {
+	data := &Comment{
+		ID:       1,
+		ClientID: "123e4567-e89b-12d3-a456-426655440000",
+		Body:     "Bar",
+		Likes: []*Likes{
+			&Likes{
+				Count: 1,
+			},
+			&Likes{
+				Count: 2,
+			},
+		},
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayloadWithoutIncluded(out, data); err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(out.String())
+
+	//if expectedBody != out.String() { t.Fatal("Marshalled body not expected") }
 
 	resp := new(OnePayload)
 	if err := json.NewDecoder(out).Decode(resp); err != nil {


### PR DESCRIPTION
## Description

We currently do not have the ability to marshal complex data structures in the `attr` tag of a struct. This PR adds that ability for Pointers and for Slices of structs.

It also refactors the the existing marshalling code to a separate function to handle the various field types.