### PR TITLE
Unmarshal Links type to 'links' annotated struct fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ used as the key in the `relationships` hash for the record. The optional
 third argument is `omitempty` - if present will prevent non existent to-one and
 to-many from being serialized.
 
+#### `links`
+
+*Note: This annotation is an added feature independent of the canonical google/jsonapi package*
+
+```
+`jsonapi:"links,omitempty"`
+```
+
+A field annotated with `links` will have the links members of the request unmarshaled to it. Note
+that this field should _always_ be annotated with `omitempty`, as marshaling of links members is
+instead handled by the `Linkable` interface (see `Links` below).
+
 ## Methods Reference
 
 **All `Marshal` and `Unmarshal` methods expect pointers to struct

--- a/constants.go
+++ b/constants.go
@@ -7,6 +7,7 @@ const (
 	annotationClientID  = "client-id"
 	annotationAttribute = "attr"
 	annotationRelation  = "relation"
+	annotationLinks     = "links"
 	annotationOmitEmpty = "omitempty"
 	annotationISO8601   = "iso8601"
 	annotationRFC3339   = "rfc3339"
@@ -53,4 +54,8 @@ const (
 	// QueryParamPageCursor is a JSON API query parameter used with a cursor-based
 	// strategy
 	QueryParamPageCursor = "page[cursor]"
+
+	// KeySelfLink is the key within a top-level links object that denotes the link that
+	// generated the current response document.
+	KeySelfLink = "self"
 )

--- a/models_test.go
+++ b/models_test.go
@@ -51,6 +51,8 @@ type Post struct {
 	Body          string     `jsonapi:"attr,body"`
 	Comments      []*Comment `jsonapi:"relation,comments"`
 	LatestComment *Comment   `jsonapi:"relation,latest_comment"`
+
+	Links Links `jsonapi:"links,omitempty"`
 }
 
 type Comment struct {
@@ -58,6 +60,8 @@ type Comment struct {
 	ClientID string `jsonapi:"client-id"`
 	PostID   int    `jsonapi:"attr,post_id"`
 	Body     string `jsonapi:"attr,body"`
+
+	Links Links `jsonapi:"links,omitempty"`
 }
 
 type Book struct {
@@ -80,6 +84,8 @@ type Blog struct {
 	CurrentPostID int       `jsonapi:"attr,current_post_id"`
 	CreatedAt     time.Time `jsonapi:"attr,created_at"`
 	ViewCount     int       `jsonapi:"attr,view_count"`
+
+	Links Links `jsonapi:"links,omitempty"`
 }
 
 func (b *Blog) JSONAPILinks() *Links {

--- a/request.go
+++ b/request.go
@@ -327,6 +327,47 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 
 			}
 
+		} else if annotation == annotationLinks {
+			if data.Links == nil {
+				continue
+			}
+
+			links := make(Links, len(*data.Links))
+
+			for k, v := range *data.Links {
+				link := v // default case (including string urls)
+
+				// Unmarshal link objects to Link
+				if t, ok := v.(map[string]interface{}); ok {
+					unmarshaledHref := ""
+					href, ok := t["href"].(string)
+					if ok {
+						unmarshaledHref = href
+					}
+
+					unmarshaledMeta := make(Meta)
+					meta, ok := t["meta"].(map[string]interface{})
+					if ok {
+						for metaK, metaV := range meta {
+							unmarshaledMeta[metaK] = metaV
+						}
+					}
+
+					link = Link{
+						Href: unmarshaledHref,
+						Meta: unmarshaledMeta,
+					}
+				}
+
+				links[k] = link
+			}
+
+			if err != nil {
+				er = err
+				break
+			}
+
+			assign(fieldValue, reflect.ValueOf(links))
 		} else {
 			er = fmt.Errorf(unsupportedStructTagMsg, annotation)
 		}

--- a/request.go
+++ b/request.go
@@ -346,8 +346,7 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 					}
 
 					unmarshaledMeta := make(Meta)
-					meta, ok := t["meta"].(map[string]interface{})
-					if ok {
+					if meta, ok := t["meta"].(map[string]interface{}); ok {
 						for metaK, metaV := range meta {
 							unmarshaledMeta[metaK] = metaV
 						}

--- a/response.go
+++ b/response.go
@@ -447,7 +447,9 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 					}
 				}
 			}
-
+		} else if annotation == annotationLinks {
+			// Nothing. Ignore this field, as Links fields are only for unmarshaling requests.
+			// The Linkable interface methods are used for marshaling data in a response.
 		} else {
 			er = ErrBadJSONAPIStructTag
 			break


### PR DESCRIPTION
These changes add the ability to unmarshal links members to links-annotated struct fields.

The specification for links members can be found here: https://jsonapi.org/format/#document-links

Note that this does not change the existing marshaling behavior of links (the Linkable interface methods), though a fully fleshed out implementation probably should - it's awkward that now interface methods are used to marshal but struct fields for unmarshaling.

In other words, an implementation of links marshaling similar to the implementation proposed in PR 58 of the canonical google/jsonapi repository would be most appropriate to pair with these unmarshaling changes. The actual implementation that was accepted is PR 57, utilizing those Linkable/Metable interfaces.

From 57:

> After looking at both implementations, I think I'd like to vote for this one because it feels flexible, and doesn't add any additional fields to our structs. In general I don't think LINK and META objects really have much to do with the resource objects themselves, they are really more related to the context in which the object is used. This approach keeps structs cleaner.

This is somewhat incorrect, and assumes that this package is always used in the context of a server and not a client (which appears to be the case in general for google/jsonapi). In a client, links members in responses can contain information that is vital to the functionality of the resource itself, so we add the ability to fetch that information here (and leave the weirdness of marshaling using a different mechanism for another day).

<details><summary>Test Output</summary>

```plaintext
» go test -v
=== RUN   TestErrorObjectWritesExpectedErrorMessage
--- PASS: TestErrorObjectWritesExpectedErrorMessage (0.00s)
=== RUN   TestMarshalErrorsWritesTheExpectedPayload
=== RUN   TestMarshalErrorsWritesTheExpectedPayload/TestFieldsAreSerializedAsNeeded
=== RUN   TestMarshalErrorsWritesTheExpectedPayload/TestMetaFieldIsSerializedProperly
--- PASS: TestMarshalErrorsWritesTheExpectedPayload (0.00s)
    --- PASS: TestMarshalErrorsWritesTheExpectedPayload/TestFieldsAreSerializedAsNeeded (0.00s)
    --- PASS: TestMarshalErrorsWritesTheExpectedPayload/TestMetaFieldIsSerializedProperly (0.00s)
=== RUN   TestUnmarshall_attrStringSlice
--- PASS: TestUnmarshall_attrStringSlice (0.00s)
=== RUN   TestUnmarshalToStructWithPointerAttr
--- PASS: TestUnmarshalToStructWithPointerAttr (0.00s)
=== RUN   TestUnmarshalPayload_missingTypeFieldShouldError
--- PASS: TestUnmarshalPayload_missingTypeFieldShouldError (0.00s)
=== RUN   TestUnmarshalPayload_ptrsAllNil
--- PASS: TestUnmarshalPayload_ptrsAllNil (0.00s)
=== RUN   TestUnmarshalPayloadWithPointerID
--- PASS: TestUnmarshalPayloadWithPointerID (0.00s)
=== RUN   TestUnmarshalPayloadWithPointerAttr_AbsentVal
--- PASS: TestUnmarshalPayloadWithPointerAttr_AbsentVal (0.00s)
=== RUN   TestUnmarshalToStructWithPointerAttr_BadType_bool
--- PASS: TestUnmarshalToStructWithPointerAttr_BadType_bool (0.00s)
=== RUN   TestUnmarshalToStructWithPointerAttr_BadType_MapPtr
--- PASS: TestUnmarshalToStructWithPointerAttr_BadType_MapPtr (0.00s)
=== RUN   TestUnmarshalToStructWithPointerAttr_BadType_Struct
--- PASS: TestUnmarshalToStructWithPointerAttr_BadType_Struct (0.00s)
=== RUN   TestUnmarshalToStructWithPointerAttr_BadType_IntSlice
--- PASS: TestUnmarshalToStructWithPointerAttr_BadType_IntSlice (0.00s)
=== RUN   TestStringPointerField
--- PASS: TestStringPointerField (0.00s)
=== RUN   TestMalformedTag
--- PASS: TestMalformedTag (0.00s)
=== RUN   TestUnmarshalInvalidJSON
--- PASS: TestUnmarshalInvalidJSON (0.00s)
=== RUN   TestUnmarshalInvalidJSON_BadType
=== RUN   TestUnmarshalInvalidJSON_BadType/Test_string_field
=== RUN   TestUnmarshalInvalidJSON_BadType/Test_float_field
=== RUN   TestUnmarshalInvalidJSON_BadType/Test_time_field
=== RUN   TestUnmarshalInvalidJSON_BadType/Test_time_ptr_field
--- PASS: TestUnmarshalInvalidJSON_BadType (0.00s)
    --- PASS: TestUnmarshalInvalidJSON_BadType/Test_string_field (0.00s)
    --- PASS: TestUnmarshalInvalidJSON_BadType/Test_float_field (0.00s)
    --- PASS: TestUnmarshalInvalidJSON_BadType/Test_time_field (0.00s)
    --- PASS: TestUnmarshalInvalidJSON_BadType/Test_time_ptr_field (0.00s)
=== RUN   TestUnmarshalSetsID
--- PASS: TestUnmarshalSetsID (0.00s)
=== RUN   TestUnmarshal_nonNumericID
--- PASS: TestUnmarshal_nonNumericID (0.00s)
=== RUN   TestUnmarshalSetsAttrs
--- PASS: TestUnmarshalSetsAttrs (0.00s)
=== RUN   TestUnmarshal_Times
=== RUN   TestUnmarshal_Times/default_byValue
=== RUN   TestUnmarshal_Times/default_byPointer
=== RUN   TestUnmarshal_Times/default_invalid
=== RUN   TestUnmarshal_Times/iso8601_byValue
=== RUN   TestUnmarshal_Times/iso8601_byPointer
=== RUN   TestUnmarshal_Times/iso8601_invalid
=== RUN   TestUnmarshal_Times/rfc3339_byValue
=== RUN   TestUnmarshal_Times/rfc3339_byPointer
=== RUN   TestUnmarshal_Times/rfc3339_invalid
--- PASS: TestUnmarshal_Times (0.00s)
    --- PASS: TestUnmarshal_Times/default_byValue (0.00s)
    --- PASS: TestUnmarshal_Times/default_byPointer (0.00s)
    --- PASS: TestUnmarshal_Times/default_invalid (0.00s)
    --- PASS: TestUnmarshal_Times/iso8601_byValue (0.00s)
    --- PASS: TestUnmarshal_Times/iso8601_byPointer (0.00s)
    --- PASS: TestUnmarshal_Times/iso8601_invalid (0.00s)
    --- PASS: TestUnmarshal_Times/rfc3339_byValue (0.00s)
    --- PASS: TestUnmarshal_Times/rfc3339_byPointer (0.00s)
    --- PASS: TestUnmarshal_Times/rfc3339_invalid (0.00s)
=== RUN   TestUnmarshalRelationshipsWithoutIncluded
--- PASS: TestUnmarshalRelationshipsWithoutIncluded (0.00s)
=== RUN   TestUnmarshalRelationships
--- PASS: TestUnmarshalRelationships (0.00s)
=== RUN   TestUnmarshalNullRelationship
--- PASS: TestUnmarshalNullRelationship (0.00s)
=== RUN   TestUnmarshalNullRelationshipInSlice
--- PASS: TestUnmarshalNullRelationshipInSlice (0.00s)
=== RUN   TestUnmarshalNestedRelationships
--- PASS: TestUnmarshalNestedRelationships (0.00s)
=== RUN   TestUnmarshalRelationshipsSerializedEmbedded
--- PASS: TestUnmarshalRelationshipsSerializedEmbedded (0.00s)
=== RUN   TestUnmarshalNestedRelationshipsEmbedded
--- PASS: TestUnmarshalNestedRelationshipsEmbedded (0.00s)
=== RUN   TestUnmarshalRelationshipsSideloaded
--- PASS: TestUnmarshalRelationshipsSideloaded (0.00s)
=== RUN   TestUnmarshalNestedRelationshipsSideloaded
--- PASS: TestUnmarshalNestedRelationshipsSideloaded (0.00s)
=== RUN   TestUnmarshalNestedRelationshipsEmbedded_withClientIDs
--- PASS: TestUnmarshalNestedRelationshipsEmbedded_withClientIDs (0.00s)
=== RUN   TestUnmarshalLinks
--- PASS: TestUnmarshalLinks (0.00s)
=== RUN   TestUnmarshalManyPayload
--- PASS: TestUnmarshalManyPayload (0.00s)
=== RUN   TestOnePayload_withLinks
--- PASS: TestOnePayload_withLinks (0.00s)
=== RUN   TestManyPayload_withLinks
--- PASS: TestManyPayload_withLinks (0.00s)
=== RUN   TestUnmarshalCustomTypeAttributes
--- PASS: TestUnmarshalCustomTypeAttributes (0.00s)
=== RUN   TestUnmarshalCustomTypeAttributes_ErrInvalidType
--- PASS: TestUnmarshalCustomTypeAttributes_ErrInvalidType (0.00s)
=== RUN   TestUnmarshalNestedStructPtr
--- PASS: TestUnmarshalNestedStructPtr (0.00s)
=== RUN   TestUnmarshalNestedStruct
--- PASS: TestUnmarshalNestedStruct (0.00s)
=== RUN   TestUnmarshalNestedStructSlice
--- PASS: TestUnmarshalNestedStructSlice (0.00s)
=== RUN   TestUnmarshalNestedStructPointerSlice
--- PASS: TestUnmarshalNestedStructPointerSlice (0.00s)
=== RUN   TestMarshalPayload
--- PASS: TestMarshalPayload (0.00s)
=== RUN   TestMarshalPayloadWithNulls
--- PASS: TestMarshalPayloadWithNulls (0.00s)
=== RUN   TestMarshal_attrStringSlice
--- PASS: TestMarshal_attrStringSlice (0.00s)
=== RUN   TestWithoutOmitsEmptyAnnotationOnRelation
--- PASS: TestWithoutOmitsEmptyAnnotationOnRelation (0.00s)
=== RUN   TestWithOmitsEmptyAnnotationOnRelation
--- PASS: TestWithOmitsEmptyAnnotationOnRelation (0.00s)
=== RUN   TestWithOmitsEmptyAnnotationOnRelation_MixedData
--- PASS: TestWithOmitsEmptyAnnotationOnRelation_MixedData (0.00s)
=== RUN   TestWithOmitsEmptyAnnotationOnAttribute
--- PASS: TestWithOmitsEmptyAnnotationOnAttribute (0.00s)
=== RUN   TestMarshalIDPtr
--- PASS: TestMarshalIDPtr (0.00s)
=== RUN   TestMarshalOnePayload_omitIDString
--- PASS: TestMarshalOnePayload_omitIDString (0.00s)
=== RUN   TestMarshall_invalidIDType
--- PASS: TestMarshall_invalidIDType (0.00s)
=== RUN   TestOmitsEmptyAnnotation
--- PASS: TestOmitsEmptyAnnotation (0.00s)
=== RUN   TestHasPrimaryAnnotation
--- PASS: TestHasPrimaryAnnotation (0.00s)
=== RUN   TestSupportsAttributes
--- PASS: TestSupportsAttributes (0.00s)
=== RUN   TestOmitsZeroTimes
--- PASS: TestOmitsZeroTimes (0.00s)
=== RUN   TestMarshal_Times
=== RUN   TestMarshal_Times/default_byValue
=== RUN   TestMarshal_Times/default_byPointer
=== RUN   TestMarshal_Times/iso8601_byValue
=== RUN   TestMarshal_Times/iso8601_byPointer
=== RUN   TestMarshal_Times/rfc3339_byValue
=== RUN   TestMarshal_Times/rfc3339_byPointer
--- PASS: TestMarshal_Times (0.00s)
    --- PASS: TestMarshal_Times/default_byValue (0.00s)
    --- PASS: TestMarshal_Times/default_byPointer (0.00s)
    --- PASS: TestMarshal_Times/iso8601_byValue (0.00s)
    --- PASS: TestMarshal_Times/iso8601_byPointer (0.00s)
    --- PASS: TestMarshal_Times/rfc3339_byValue (0.00s)
    --- PASS: TestMarshal_Times/rfc3339_byPointer (0.00s)
=== RUN   TestSupportsLinkable
--- PASS: TestSupportsLinkable (0.00s)
=== RUN   TestInvalidLinkable
--- PASS: TestInvalidLinkable (0.00s)
=== RUN   TestSupportsMetable
--- PASS: TestSupportsMetable (0.00s)
=== RUN   TestRelations
--- PASS: TestRelations (0.00s)
=== RUN   TestNoRelations
--- PASS: TestNoRelations (0.00s)
=== RUN   TestMarshalPayloadWithoutIncluded
--- PASS: TestMarshalPayloadWithoutIncluded (0.00s)
=== RUN   TestMarshalPayload_many
--- PASS: TestMarshalPayload_many (0.00s)
=== RUN   TestMarshalMany_WithSliceOfStructPointers
--- PASS: TestMarshalMany_WithSliceOfStructPointers (0.00s)
=== RUN   TestMarshalManyWithoutIncluded
--- PASS: TestMarshalManyWithoutIncluded (0.00s)
=== RUN   TestMarshalMany_SliceOfInterfaceAndSliceOfStructsSameJSON
--- PASS: TestMarshalMany_SliceOfInterfaceAndSliceOfStructsSameJSON (0.00s)
=== RUN   TestMarshal_InvalidIntefaceArgument
--- PASS: TestMarshal_InvalidIntefaceArgument (0.00s)
PASS
ok      github.com/hashicorp/jsonapi    0.101s
```

</details>