### PR TITLE
Support polymorphic relationships through a join struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ all of your data easily.
 
 ## Example App
 
-[examples/app.go](https://github.com/google/jsonapi/blob/master/examples/app.go)
+[examples/app.go](https://github.com/hashicorp/jsonapi/blob/main/examples/app.go)
 
 This program demonstrates the implementation of a create, a show,
 and a list [http.Handler](http://golang.org/pkg/net/http#Handler).  It
@@ -521,13 +521,13 @@ I use git subtrees to manage dependencies rather than `go get` so that
 the src is committed to my repo.
 
 ```
-git subtree add --squash --prefix=src/github.com/google/jsonapi https://github.com/google/jsonapi.git master
+git subtree add --squash --prefix=src/github.com/hashicorp/jsonapi https://github.com/hashicorp/jsonapi.git main
 ```
 
 To update,
 
 ```
-git subtree pull --squash --prefix=src/github.com/google/jsonapi https://github.com/google/jsonapi.git master
+git subtree pull --squash --prefix=src/github.com/hashicorp/jsonapi https://github.com/hashicorp/jsonapi.git main
 ```
 
 This assumes that I have my repo structured with a `src` dir containing

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ to-many from being serialized.
 ```
 
 Polymorphic relations can be represented exactly as relations, except that
-an intermediate type is needed within your model struct that will be populated
-with exactly one value among all the fields in that struct.
+an intermediate type is needed within your model struct that provides a choice
+for the actual value to be populated within.
 
 Example:
 
@@ -220,14 +220,18 @@ type Post struct {
 ```
 
 During decoding, the `polyrelation` annotation instructs jsonapi to assign each relationship
-to either `Video` or `Image` within the value of the associated field. This value must be
-a pointer to a struct containing other pointer fields to jsonapi models. The actual field
-assignment depends on that type having a jsonapi "primary" annotation with a type matching
-the relationship type found in the response. All other fields will be remain nil.
+to either `Video` or `Image` within the value of the associated field, provided that the
+payload contains either a "videos" or "images" type. This field value must be
+a pointer to a special choice type struct (also known as a tagged union, or sum type) containing
+other pointer fields to jsonapi models. The actual field assignment depends on that type having
+a jsonapi "primary" annotation with a type matching the relationship type found in the response.
+All other fields will be remain empty. If no matching types are represented by the choice type,
+all fields will be empty.
 
 During encoding, the very first non-nil field will be used to populate the payload. Others
-will be ignored. Therefore, it's critical to set the value of only one field within the join
-struct.
+will be ignored. Therefore, it's critical to set the value of only one field within the choice
+struct. When accepting input values on this type of choice type, it would a good idea to enforce
+and check that the value is set on only one field.
 
 #### `links`
 

--- a/constants.go
+++ b/constants.go
@@ -2,16 +2,17 @@ package jsonapi
 
 const (
 	// StructTag annotation strings
-	annotationJSONAPI   = "jsonapi"
-	annotationPrimary   = "primary"
-	annotationClientID  = "client-id"
-	annotationAttribute = "attr"
-	annotationRelation  = "relation"
-	annotationLinks     = "links"
-	annotationOmitEmpty = "omitempty"
-	annotationISO8601   = "iso8601"
-	annotationRFC3339   = "rfc3339"
-	annotationSeperator = ","
+	annotationJSONAPI      = "jsonapi"
+	annotationPrimary      = "primary"
+	annotationClientID     = "client-id"
+	annotationAttribute    = "attr"
+	annotationRelation     = "relation"
+	annotationPolyRelation = "polyrelation"
+	annotationLinks        = "links"
+	annotationOmitEmpty    = "omitempty"
+	annotationISO8601      = "iso8601"
+	annotationRFC3339      = "rfc3339"
+	annotationSeperator    = ","
 
 	iso8601TimeFormat = "2006-01-02T15:04:05Z"
 

--- a/constants.go
+++ b/constants.go
@@ -12,7 +12,7 @@ const (
 	annotationOmitEmpty    = "omitempty"
 	annotationISO8601      = "iso8601"
 	annotationRFC3339      = "rfc3339"
-	annotationSeperator    = ","
+	annotationSeparator    = ","
 
 	iso8601TimeFormat = "2006-01-02T15:04:05Z"
 

--- a/examples/app.go
+++ b/examples/app.go
@@ -10,7 +10,7 @@ import (
 	"net/http/httptest"
 	"time"
 
-	"github.com/google/jsonapi"
+	"github.com/hashicorp/jsonapi"
 )
 
 func main() {

--- a/examples/handler.go
+++ b/examples/handler.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/jsonapi"
+	"github.com/hashicorp/jsonapi"
 )
 
 const (

--- a/examples/handler_test.go
+++ b/examples/handler_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/google/jsonapi"
+	"github.com/hashicorp/jsonapi"
 )
 
 func TestExampleHandler_post(t *testing.T) {

--- a/examples/models.go
+++ b/examples/models.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/jsonapi"
+	"github.com/hashicorp/jsonapi"
 )
 
 // Blog is a model representing a blog site

--- a/models_test.go
+++ b/models_test.go
@@ -212,3 +212,27 @@ type CustomAttributeTypes struct {
 	Float  CustomFloatType  `jsonapi:"attr,float"`
 	String CustomStringType `jsonapi:"attr,string"`
 }
+
+type Image struct {
+	ID  string `jsonapi:"primary,images"`
+	Src string `jsonapi:"attr,src"`
+}
+
+type Video struct {
+	ID       string `jsonapi:"primary,videos"`
+	Captions string `jsonapi:"attr,captions"`
+}
+
+type OneOfMedia struct {
+	Image       *Image
+	random      int
+	Video       *Video
+	RandomStuff *string
+}
+
+type BlogPostWithPoly struct {
+	ID    string        `jsonapi:"primary,blogs"`
+	Title string        `jsonapi:"attr,title"`
+	Hero  *OneOfMedia   `jsonapi:"polyrelation,hero-media,omitempty"`
+	Media []*OneOfMedia `jsonapi:"polyrelation,media,omitempty"`
+}

--- a/request.go
+++ b/request.go
@@ -32,9 +32,6 @@ var (
 	ErrUnknownFieldNumberType = errors.New("The struct field was not of a known number type")
 	// ErrInvalidType is returned when the given type is incompatible with the expected type.
 	ErrInvalidType = errors.New("Invalid type provided") // I wish we used punctuation.
-	// ErrBadJSONAPIJoinStruct is returned when the polyrelation type did not contain
-	// an appropriate join type to contain the required jsonapi node.
-	ErrBadJSONAPIJoinStruct = errors.New("Invalid join struct for polymorphic relation field")
 )
 
 // ErrUnsupportedPtrType is returned when the Struct field was a pointer but
@@ -245,8 +242,11 @@ func unmarshalNodeMaybeChoice(m *reflect.Value, data *Node, annotation string, c
 	if annotation == annotationPolyRelation {
 		c, ok := choiceTypeMapping[data.Type]
 		if !ok {
-			// There is no valid join field to assign this type of relation.
-			return ErrBadJSONAPIJoinStruct
+			// If there is no valid choice field to assign this type of relation,
+			// this shouldn't necessarily be an error because a newer version of
+			// the API could be communicating with an older version of the client
+			// library, in which case all choice variants would be nil.
+			return nil
 		}
 		choiceElem = &c
 		actualModel = reflect.New(choiceElem.Type)

--- a/request.go
+++ b/request.go
@@ -193,11 +193,18 @@ func choiceStructMapping(choice reflect.Type) (result map[string]structFieldInde
 	for i := 0; i < choice.NumField(); i++ {
 		fieldType := choice.Field(i)
 
+		// Must be a pointer
 		if fieldType.Type.Kind() != reflect.Ptr {
 			continue
 		}
 
 		subtype := fieldType.Type.Elem()
+
+		// Must be a pointer to struct
+		if subtype.Kind() != reflect.Struct {
+			continue
+		}
+
 		if t, err := jsonapiTypeOfModel(subtype); err == nil {
 			result[t] = structFieldIndex{
 				Type:     subtype,

--- a/request.go
+++ b/request.go
@@ -69,24 +69,23 @@ func newErrUnsupportedPtrType(rf reflect.Value, t reflect.Type, structField refl
 // For example you could pass it, in, req.Body and, model, a BlogPost
 // struct instance to populate in an http handler,
 //
-//   func CreateBlog(w http.ResponseWriter, r *http.Request) {
-//   	blog := new(Blog)
+//	func CreateBlog(w http.ResponseWriter, r *http.Request) {
+//		blog := new(Blog)
 //
-//   	if err := jsonapi.UnmarshalPayload(r.Body, blog); err != nil {
-//   		http.Error(w, err.Error(), 500)
-//   		return
-//   	}
+//		if err := jsonapi.UnmarshalPayload(r.Body, blog); err != nil {
+//			http.Error(w, err.Error(), 500)
+//			return
+//		}
 //
-//   	// ...do stuff with your blog...
+//		// ...do stuff with your blog...
 //
-//   	w.Header().Set("Content-Type", jsonapi.MediaType)
-//   	w.WriteHeader(201)
+//		w.Header().Set("Content-Type", jsonapi.MediaType)
+//		w.WriteHeader(201)
 //
-//   	if err := jsonapi.MarshalPayload(w, blog); err != nil {
-//   		http.Error(w, err.Error(), 500)
-//   	}
-//   }
-//
+//		if err := jsonapi.MarshalPayload(w, blog); err != nil {
+//			http.Error(w, err.Error(), 500)
+//		}
+//	}
 //
 // Visit https://github.com/google/jsonapi#create for more info.
 //

--- a/request_test.go
+++ b/request_test.go
@@ -697,7 +697,7 @@ func Test_UnmarshalPayload_polymorphicRelations(t *testing.T) {
 	}
 }
 
-func Test_joinStructMapping(t *testing.T) {
+func Test_choiceStructMapping(t *testing.T) {
 	cases := []struct {
 		val reflect.Type
 	}{
@@ -706,7 +706,7 @@ func Test_joinStructMapping(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		result, err := joinStructMapping(c.val)
+		result, err := choiceStructMapping(c.val)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/request_test.go
+++ b/request_test.go
@@ -734,6 +734,37 @@ func Test_UnmarshalPayload_polymorphicRelations_no_choice(t *testing.T) {
 	}
 }
 
+func Test_UnmarshalPayload_polymorphicRelations_omitted(t *testing.T) {
+	type pointerToOne struct {
+		ID    string      `jsonapi:"primary,blogs"`
+		Title string      `jsonapi:"attr,title"`
+		Hero  *OneOfMedia `jsonapi:"polyrelation,hero-media"`
+	}
+
+	in := bytes.NewReader([]byte(`{
+		"data": {
+			"type": "blogs",
+			"id":   "3",
+			"attributes": {
+				"title": "Hello, World"
+			}
+		}
+	}`))
+	out := new(pointerToOne)
+
+	if err := UnmarshalPayload(in, out); err != nil {
+		t.Fatal(err)
+	}
+
+	if out.Title != "Hello, World" {
+		t.Errorf("expected Title %q but got %q", "Hello, World", out.Title)
+	}
+
+	if out.Hero != nil {
+		t.Fatalf("expected Hero to be nil, but got %+v", out.Hero)
+	}
+}
+
 func Test_choiceStructMapping(t *testing.T) {
 	cases := []struct {
 		val reflect.Type

--- a/request_test.go
+++ b/request_test.go
@@ -618,8 +618,10 @@ type Video struct {
 }
 
 type OneOfMedia struct {
-	Image *Image
-	Video *Video
+	Image       *Image
+	random      int
+	Video       *Video
+	RandomStuff *string
 }
 
 func Test_UnmarshalPayload_polymorphicRelations(t *testing.T) {
@@ -774,8 +776,8 @@ func Test_choiceStructMapping(t *testing.T) {
 			t.Errorf("expected \"images\" to be the first field, but got %d", imageField.FieldNum)
 		}
 		videoField, ok := result["videos"]
-		if !ok || videoField.FieldNum != 1 {
-			t.Errorf("expected \"videos\" to be the second field, but got %d", videoField.FieldNum)
+		if !ok || videoField.FieldNum != 2 {
+			t.Errorf("expected \"videos\" to be the third field, but got %d", videoField.FieldNum)
 		}
 	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -607,31 +607,7 @@ func TestUnmarshalRelationships(t *testing.T) {
 	}
 }
 
-type Image struct {
-	ID  int    `jsonapi:"primary,images"`
-	Src string `jsonapi:"attr,src"`
-}
-
-type Video struct {
-	ID       int    `jsonapi:"primary,videos"`
-	Captions string `jsonapi:"attr,captions"`
-}
-
-type OneOfMedia struct {
-	Image       *Image
-	random      int
-	Video       *Video
-	RandomStuff *string
-}
-
 func Test_UnmarshalPayload_polymorphicRelations(t *testing.T) {
-	type pointerToOne struct {
-		ID    int           `jsonapi:"primary,blogs"`
-		Title string        `jsonapi:"attr,title"`
-		Hero  *OneOfMedia   `jsonapi:"polyrelation,hero-media,omitempty"`
-		Media []*OneOfMedia `jsonapi:"polyrelation,media,omitempty"`
-	}
-
 	in := bytes.NewReader([]byte(`{
 		"data": {
 			"type": "blogs",
@@ -684,7 +660,7 @@ func Test_UnmarshalPayload_polymorphicRelations(t *testing.T) {
 			}
 		]
 	}`))
-	out := new(pointerToOne)
+	out := new(BlogPostWithPoly)
 
 	if err := UnmarshalPayload(in, out); err != nil {
 		t.Fatal(err)
@@ -714,7 +690,7 @@ func Test_UnmarshalPayload_polymorphicRelations(t *testing.T) {
 
 func Test_UnmarshalPayload_polymorphicRelations_no_choice(t *testing.T) {
 	type pointerToOne struct {
-		ID    int         `jsonapi:"primary,blogs"`
+		ID    string      `jsonapi:"primary,blogs"`
 		Title string      `jsonapi:"attr,title"`
 		Hero  *OneOfMedia `jsonapi:"polyrelation,hero-media,omitempty"`
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -743,10 +743,7 @@ func Test_choiceStructMapping(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		result, err := choiceStructMapping(c.val)
-		if err != nil {
-			t.Fatal(err)
-		}
+		result := choiceStructMapping(c.val)
 		imageField, ok := result["images"]
 		if !ok || imageField.FieldNum != 0 {
 			t.Errorf("expected \"images\" to be the first field, but got %d", imageField.FieldNum)

--- a/response.go
+++ b/response.go
@@ -193,7 +193,10 @@ func MarshalOnePayloadEmbedded(w io.Writer, model interface{}) error {
 	return json.NewEncoder(w).Encode(payload)
 }
 
-func chooseFirstNonNilFieldValue(structValue reflect.Value) (reflect.Value, error) {
+// selectChoiceTypeStructField returns the first non-nil struct pointer field in the
+// specified struct value that has a jsonapi type field defined within it.
+// An error is returned if there are no fields matching that definition.
+func selectChoiceTypeStructField(structValue reflect.Value) (reflect.Value, error) {
 	for i := 0; i < structValue.NumField(); i++ {
 		choiceFieldValue := structValue.Field(i)
 		choiceTypeField := choiceFieldValue.Type()
@@ -416,7 +419,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 					}
 
 					structValue := choiceValue.Elem()
-					if found, err := chooseFirstNonNilFieldValue(structValue); err == nil {
+					if found, err := selectChoiceTypeStructField(structValue); err == nil {
 						fieldValue = found
 					}
 				} else {
@@ -442,7 +445,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 
 						structValue := itemValue.Elem()
 
-						if found, err := chooseFirstNonNilFieldValue(structValue); err == nil {
+						if found, err := selectChoiceTypeStructField(structValue); err == nil {
 							collection = append(collection, found.Interface())
 						}
 					}

--- a/response.go
+++ b/response.go
@@ -51,17 +51,16 @@ var (
 // Many Example: you could pass it, w, your http.ResponseWriter, and, models, a
 // slice of Blog struct instance pointers to be written to the response body:
 //
-//	 func ListBlogs(w http.ResponseWriter, r *http.Request) {
-//     blogs := []*Blog{}
+//		 func ListBlogs(w http.ResponseWriter, r *http.Request) {
+//	    blogs := []*Blog{}
 //
-//		 w.Header().Set("Content-Type", jsonapi.MediaType)
-//		 w.WriteHeader(http.StatusOK)
+//			 w.Header().Set("Content-Type", jsonapi.MediaType)
+//			 w.WriteHeader(http.StatusOK)
 //
-//		 if err := jsonapi.MarshalPayload(w, blogs); err != nil {
-//			 http.Error(w, err.Error(), http.StatusInternalServerError)
+//			 if err := jsonapi.MarshalPayload(w, blogs); err != nil {
+//				 http.Error(w, err.Error(), http.StatusInternalServerError)
+//			 }
 //		 }
-//	 }
-//
 func MarshalPayload(w io.Writer, models interface{}) error {
 	payload, err := Marshal(models)
 	if err != nil {

--- a/response.go
+++ b/response.go
@@ -406,7 +406,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 					choiceValue := fieldValue
 
 					// must be a pointer type
-					if choiceValue.Type().Kind() != reflect.Pointer {
+					if choiceValue.Type().Kind() != reflect.Ptr {
 						er = ErrUnexpectedType
 						break
 					}
@@ -430,7 +430,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 					for i := 0; i < fieldValue.Len(); i++ {
 						itemValue := fieldValue.Index(i)
 						// Once again, must be a pointer type
-						if itemValue.Type().Kind() != reflect.Pointer {
+						if itemValue.Type().Kind() != reflect.Ptr {
 							er = ErrUnexpectedType
 							break
 						}

--- a/response.go
+++ b/response.go
@@ -215,7 +215,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 		fieldValue := modelValue.Field(i)
 		fieldType := modelType.Field(i)
 
-		args := strings.Split(tag, annotationSeperator)
+		args := strings.Split(tag, annotationSeparator)
 
 		if len(args) < 1 {
 			er = ErrBadJSONAPIStructTag

--- a/response.go
+++ b/response.go
@@ -417,8 +417,13 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 					if choiceValue.IsNil() {
 						fieldValue = reflect.ValueOf(nil)
 					}
-
 					structValue := choiceValue.Elem()
+
+					// Short circuit if field is omitted from model
+					if !structValue.IsValid() {
+						break
+					}
+
 					if found, err := selectChoiceTypeStructField(structValue); err == nil {
 						fieldValue = found
 					}

--- a/response_test.go
+++ b/response_test.go
@@ -3,6 +3,7 @@ package jsonapi
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -40,6 +41,26 @@ func TestMarshalPayload(t *testing.T) {
 
 func TestMarshalPayloadWithNulls(t *testing.T) {
 
+func TestMarshalPayloadWithManyRelationWithNils(t *testing.T) {
+	blog := &Blog{
+		ID:    1,
+		Title: "Hello, World",
+		Posts: []*Post{
+			nil,
+			{
+				ID: 2,
+			},
+			nil,
+		},
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, blog); !errors.Is(err, ErrUnexpectedNil) {
+		t.Fatal("expected error but got none")
+	}
+}
+
+func TestMarshalPayloadWithNulls(t *testing.T) {
 	books := []*Book{nil, {ID: 101}, nil}
 	var jsonData map[string]interface{}
 

--- a/response_test.go
+++ b/response_test.go
@@ -3,7 +3,6 @@ package jsonapi
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -150,7 +149,7 @@ func TestMarshalPayloadWithManyPolyrelationWithNils(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, blog); !errors.Is(err, ErrUnexpectedNil) {
+	if err := MarshalPayload(out, blog); err != ErrUnexpectedNil {
 		t.Fatal("expected error but got none")
 	}
 }
@@ -169,7 +168,7 @@ func TestMarshalPayloadWithManyRelationWithNils(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, blog); !errors.Is(err, ErrUnexpectedNil) {
+	if err := MarshalPayload(out, blog); err != ErrUnexpectedNil {
 		t.Fatal("expected error but got none")
 	}
 }

--- a/response_test.go
+++ b/response_test.go
@@ -38,7 +38,7 @@ func TestMarshalPayload(t *testing.T) {
 	}
 }
 
-func TestMarshalPayloadWithOnePolyrelation(t *testing.T) {
+func TestMarshalPayloadWithHasOnePolyrelation(t *testing.T) {
 	blog := &BlogPostWithPoly{
 		ID:    "1",
 		Title: "Hello, World",
@@ -77,7 +77,7 @@ func TestMarshalPayloadWithOnePolyrelation(t *testing.T) {
 	}
 }
 
-func TestMarshalPayloadWithManyPolyrelation(t *testing.T) {
+func TestMarshalPayloadWithHasManyPolyrelation(t *testing.T) {
 	blog := &BlogPostWithPoly{
 		ID:    "1",
 		Title: "Hello, World",
@@ -133,7 +133,7 @@ func TestMarshalPayloadWithManyPolyrelation(t *testing.T) {
 	}
 }
 
-func TestMarshalPayloadWithManyPolyrelationWithNils(t *testing.T) {
+func TestMarshalPayloadWithHasManyPolyrelationWithNils(t *testing.T) {
 	blog := &BlogPostWithPoly{
 		ID:    "1",
 		Title: "Hello, World",
@@ -154,7 +154,20 @@ func TestMarshalPayloadWithManyPolyrelationWithNils(t *testing.T) {
 	}
 }
 
-func TestMarshalPayloadWithManyRelationWithNils(t *testing.T) {
+func TestMarshalPayloadWithHasOneNilPolyrelation(t *testing.T) {
+	blog := &BlogPostWithPoly{
+		ID:    "1",
+		Title: "Hello, World",
+		Hero:  nil,
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, blog); err != nil {
+		t.Fatalf("expected no error but got %s", err)
+	}
+}
+
+func TestMarshalPayloadWithHasOneNilRelation(t *testing.T) {
 	blog := &Blog{
 		ID:    1,
 		Title: "Hello, World",

--- a/response_test.go
+++ b/response_test.go
@@ -167,6 +167,18 @@ func TestMarshalPayloadWithHasOneNilPolyrelation(t *testing.T) {
 	}
 }
 
+func TestMarshalPayloadWithHasOneOmittedPolyrelation(t *testing.T) {
+	blog := &BlogPostWithPoly{
+		ID:    "1",
+		Title: "Hello, World",
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, blog); err != nil {
+		t.Fatalf("expected no error but got %s", err)
+	}
+}
+
 func TestMarshalPayloadWithHasOneNilRelation(t *testing.T) {
 	blog := &Blog{
 		ID:    1,


### PR DESCRIPTION
One way of solving polymorphic relationships in jsonapi is to use a special choice type (aka tagged union, discriminated union, sum type, etc) of potential values that get populating according to the actual underlying type. The potential types are probed for their "primary" type and exactly one appropriate field is populated.

### Additions to the README:

```
`jsonapi:"polyrelation,<key name in relationships hash>,<optional: omitempty>"`
```

Polymorphic relations can be represented exactly as relations, except that
an intermediate type is needed within your model struct that will be populated
with exactly one value among all the fields in that struct.

Example:

```go
type Video struct {
	ID          int    `jsonapi:"primary,videos"`
	SourceURL   string `jsonapi:"attr,source-url"`
	CaptionsURL string `jsonapi:"attr,captions-url"`
}

type Image struct {
	ID        int    `jsonapi:"primary,images"`
	SourceURL string `jsonapi:"attr,src"`
	AltText   string `jsonapi:"attr,alt"`
}

type OneOfMedia struct {
	Video *Video
	Image *Image
}

type Post struct {
	ID      int           `jsonapi:"primary,posts"`
	Title   string        `jsonapi:"attr,title"`
	Body    string        `jsonapi:"attr,body"`
	Gallery []*OneOfMedia `jsonapi:"polyrelation,gallery"`
	Hero    *OneOfMedia   `jsonapi:"polyrelation,hero"`
}
```

During decoding, the `polyrelation` annotation instructs jsonapi to assign each relationship
to either `Video` or `Image` within the value of the associated field. This value must be
a pointer to a special choice type struct (also known as a tagged union, or sum type) containing
other pointer fields to jsonapi models. The actual field assignment depends on that type having
a jsonapi "primary" annotation with a type matching the relationship type found in the response.
All other fields will be remain nil.

During encoding, the very first non-nil field will be used to populate the payload. Others
will be ignored. Therefore, it's critical to set the value of only one field within the choice
struct. When accepting input values on this type of choice type, it would a good idea to enforce
and check that the value is set on only one field.