### PR TITLE
feat: support custom marshaling and unmarshaling for attributes

### DIFF
--- a/examples/fixtures.go
+++ b/examples/fixtures.go
@@ -1,12 +1,10 @@
 package main
 
-import "time"
-
 func fixtureBlogCreate(i int) *Blog {
 	return &Blog{
 		ID:        1 * i,
 		Title:     "Title 1",
-		CreatedAt: time.Now(),
+		CreatedAt: nil,
 		Posts: []*Post{
 			{
 				ID:    1 * i,

--- a/examples/fixtures.go
+++ b/examples/fixtures.go
@@ -1,10 +1,13 @@
 package main
 
+import "time"
+
 func fixtureBlogCreate(i int) *Blog {
+	ts := time.Now()
 	return &Blog{
 		ID:        1 * i,
 		Title:     "Title 1",
-		CreatedAt: nil,
+		CreatedAt: &UnsetableTime{&ts},
 		Posts: []*Post{
 			{
 				ID:    1 * i,

--- a/examples/models.go
+++ b/examples/models.go
@@ -20,7 +20,7 @@ func (t *UnsetableTime) MarshalAttribute() (interface{}, error) {
 	if t.Value == nil {
 		return json.RawMessage(nil), nil
 	} else {
-		return t.Value.Unix(), nil
+		return t.Value, nil
 	}
 }
 
@@ -31,7 +31,7 @@ type Blog struct {
 	Posts         []*Post        `jsonapi:"relation,posts"`
 	CurrentPost   *Post          `jsonapi:"relation,current_post"`
 	CurrentPostID int            `jsonapi:"attr,current_post_id"`
-	CreatedAt     *UnsetableTime `jsonapi:"attr,created_at,omitempty"`
+	CreatedAt     *UnsetableTime `jsonapi:"attr,created_at,omitempty,iso8601"`
 	ViewCount     int            `jsonapi:"attr,view_count"`
 }
 

--- a/examples/models.go
+++ b/examples/models.go
@@ -1,21 +1,38 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/hashicorp/jsonapi"
 )
 
+type UnsetableTime struct {
+	Value *time.Time
+}
+
+func (t *UnsetableTime) MarshalAttribute() (interface{}, error) {
+	if t == nil {
+		return nil, nil
+	}
+
+	if t.Value == nil {
+		return json.RawMessage(nil), nil
+	} else {
+		return t.Value.Unix(), nil
+	}
+}
+
 // Blog is a model representing a blog site
 type Blog struct {
-	ID            int       `jsonapi:"primary,blogs"`
-	Title         string    `jsonapi:"attr,title"`
-	Posts         []*Post   `jsonapi:"relation,posts"`
-	CurrentPost   *Post     `jsonapi:"relation,current_post"`
-	CurrentPostID int       `jsonapi:"attr,current_post_id"`
-	CreatedAt     time.Time `jsonapi:"attr,created_at"`
-	ViewCount     int       `jsonapi:"attr,view_count"`
+	ID            int            `jsonapi:"primary,blogs"`
+	Title         string         `jsonapi:"attr,title"`
+	Posts         []*Post        `jsonapi:"relation,posts"`
+	CurrentPost   *Post          `jsonapi:"relation,current_post"`
+	CurrentPostID int            `jsonapi:"attr,current_post_id"`
+	CreatedAt     *UnsetableTime `jsonapi:"attr,created_at,omitempty"`
+	ViewCount     int            `jsonapi:"attr,view_count"`
 }
 
 // Post is a model representing a post on a blog

--- a/request.go
+++ b/request.go
@@ -36,10 +36,6 @@ var (
 	ErrTypeNotFound = errors.New("no primary type annotation found on model")
 )
 
-type Unmarshaler interface {
-	UnmarshalJSON([]byte) error
-}
-
 // ErrUnsupportedPtrType is returned when the Struct field was a pointer but
 // the JSON value was of a different type
 type ErrUnsupportedPtrType struct {
@@ -313,19 +309,6 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 
 	modelValue := model.Elem()
 	modelType := modelValue.Type()
-
-	if m, ok := model.Interface().(Unmarshaler); ok {
-		data, err := json.Marshal(model)
-		if err != nil {
-			return err
-		}
-
-		if err := m.UnmarshalJSON(data); err != nil {
-			return err
-		}
-
-		return nil
-	}
 
 	var er error
 

--- a/request.go
+++ b/request.go
@@ -36,6 +36,10 @@ var (
 	ErrTypeNotFound = errors.New("no primary type annotation found on model")
 )
 
+type Unmarshaler interface {
+	UnmarshalJSON([]byte) error
+}
+
 // ErrUnsupportedPtrType is returned when the Struct field was a pointer but
 // the JSON value was of a different type
 type ErrUnsupportedPtrType struct {
@@ -309,6 +313,19 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 
 	modelValue := model.Elem()
 	modelType := modelValue.Type()
+
+	if m, ok := model.Interface().(Unmarshaler); ok {
+		data, err := json.Marshal(model)
+		if err != nil {
+			return err
+		}
+
+		if err := m.UnmarshalJSON(data); err != nil {
+			return err
+		}
+
+		return nil
+	}
 
 	var er error
 

--- a/request_test.go
+++ b/request_test.go
@@ -387,7 +387,7 @@ func TestUnmarshalSetsAttrs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if out.CreatedAt.IsZero() {
+	if out.CreatedAt.Value.IsZero() {
 		t.Fatalf("Did not parse time")
 	}
 
@@ -1431,7 +1431,7 @@ func testModel() *Blog {
 		ID:        5,
 		ClientID:  "1",
 		Title:     "Title 1",
-		CreatedAt: time.Now(),
+		CreatedAt: &UnsetableTime{&now},
 		Posts: []*Post{
 			{
 				ID:    1,

--- a/response.go
+++ b/response.go
@@ -30,6 +30,10 @@ var (
 	ErrUnexpectedNil = errors.New("slice of struct pointers cannot contain nil")
 )
 
+type Marshaler interface {
+	MarshalJSON() (*Node, error)
+}
+
 // MarshalPayload writes a jsonapi response for one or many records. The
 // related records are sideloaded into the "included" array. If this method is
 // given a struct pointer as an argument it will serialize in the form
@@ -229,6 +233,15 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 	value := reflect.ValueOf(model)
 	if value.IsNil() {
 		return nil, nil
+	}
+
+	if m, ok := model.(Marshaler); ok {
+		node, err := m.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+
+		return node, nil
 	}
 
 	modelValue := value.Elem()

--- a/response.go
+++ b/response.go
@@ -30,6 +30,11 @@ var (
 	ErrUnexpectedNil = errors.New("slice of struct pointers cannot contain nil")
 )
 
+// AttributeUnmarshaler can be implemented if custom marshaling is desired.
+// This interface behaves differently than json.Marshaler in that it returns
+// an interface rather than a byte array. The value returned can be a different
+// type than the method reciever, and will be substituted for the original value
+// as the jsonapi marshaling proceeds.
 type AttributeMarshaler interface {
 	MarshalAttribute() (interface{}, error)
 }

--- a/response.go
+++ b/response.go
@@ -342,7 +342,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 
 			// See if we need to omit this field
 			if omitEmpty {
-				if fieldValue.IsNil() {
+				if fieldValue.Interface() == nil {
 					continue
 				}
 
@@ -359,7 +359,6 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 				}
 
 				fieldValue = reflect.ValueOf(a)
-				fmt.Println(fieldValue.Type())
 			}
 
 			if fieldValue.Type() == reflect.TypeOf(time.Time{}) {


### PR DESCRIPTION
## WIP

This PR attempts support for custom marshaling and unmarshaling for resource attributes. 

The `AttributeMarshaler` and `AttributeUnmarshaler` interfaces provide methods that allow custom logic at marshal/unmarshal time.

This may prove useful for a related PR: https://github.com/hashicorp/go-tfe/pull/786

cc @nfagerlund @brandonc 

### Example use
The `UnsetableTime` type below implements the `AttributeMarshaler` and `AttributeUnmarshaler` interfaces. The methods in these interfaces allow complex attribute values to be transformed to simple values during marshaling:

```golang
type UnsetableTime struct {
	Value *time.Time
}

func (t *UnsetableTime) MarshalAttribute() (interface{}, error) {
	if t == nil {
		return nil, nil
	}

	if t.Value == nil {
		return json.RawMessage(nil), nil
	} else {
		return t.Value, nil
	}
}

func (t *UnsetableTime) UnmarshalAttribute(obj interface{}) error {
	var ts time.Time
	var err error

	if obj == nil {
		t.Value = nil
		return nil
	}

	if tsStr, ok := obj.(string); ok {
		ts, err = time.Parse(tsStr, time.RFC3339)
		if err == nil {
			t.Value = &ts
			return nil
		}
	} else if tsFloat, ok := obj.(float64); ok {
		ts = time.Unix(int64(tsFloat), 0)

		t.Value = &ts
		return nil
	}

	return errors.New("couldn't parse time")
}
```

Now you can use a pointer to the custom type in place of a primitive value like `*time.Time` in the payload struct. `omitempty` still works as expected:
```golang
type UserSetting struct {
  ID uint64 `jsonapi:"primary,user_settings"`
  Name string `jsonapi:"attr,name,omitempty"`
  AutoDestroyAt *UnsetableTime `jsonapi:"attr,auto_destroy_at,omitempty"`
}

nextWeek := time.Now().AddDate(0, 0, 7)

setTheValue  := {
  AutoDestroyAt: &UnsetableTime{&now},
}

// {
//   "data": {
//     "type": "user_settings",
//     "id": "1",
//     "attributes": { 
//       "auto_destroy_at": "2024-01-02T10:58:55-0800"
//     },
//     ...
//   }
// }

unsetTheValue  := {
  AutoDestroyAt: &UnsetableTime{ },
}

// {
//   "data": {
//     "type": "user_settings",
//     "id": "1",
//     "attributes": { 
//       "auto_destroy_at": null
//     },
//     ...
//   }
// }

keepTheExistingValue  := {
  AutoDestroyAt: nil,
}

// {
//   "data": {
//     "type": "user_settings",
//     "id": "1",
//     "attributes": { },
//     ...
//   }
// }
```

### Background
Certain HTTP API designs can lead to friction when wrapped with a Go SDK. A common case is an API endpoint whose request payload contains one or more optional attributes that, when included, communicate the users' intent to update their values:

#### Example PATCH payload for enabling `auto_destroy_at`
```json
{
  "name": "updated name",
  "auto_destroy_at": "2023-12-27T10:58:55-0800"
}
```

The payload above will update the name of the model and enable the `auto_destroy_at` toggle, while also providing a value for it to use. To unset `auto_destroy_at`, a `null` value can be passed for the attribute.

#### Example PATCH payload for disabling `auto_destroy_at`
```json
{
  "auto_destroy_at": null
}
```

Omitting the attribute from the payload allows the model to keep whatever value has been previously set.

`jsonapi` allows use of the `omitempty` struct tag to create payloads that optionally omit attributes when marshaling if they have a zero value:

####
```golang
type UserSetting struct {
  ID uint64 `jsonapi:"primary,user_settings"`
  Name string `jsonapi:"attr,name,omitempty"`
  AutoDestroyAt *time.Time `jsonapi:"attr,auto_destroy_at,omitempty"`
}
```

Unfortunately, the underlying API uses a JSON `null` for disabling the toggle, so using a corresponding `nil` value will cause the attribute to be omitted.

### Notes/Questions
- The interface methods take inspiration from `encoding/json`, but they are based on `interface{}` rather than `byte[]`. They effectively act as hooks that allow custom transformation logic during the marshaling and unmarshaling of attribute values. Is there a better verb than `Marshal` for the names of these interfaces?
- This PR attempts to support nested jsonapi nodes as attribute values, but currently **for the marshaling case only**. Control is yielded to the `jsonapi` library after a custom value is returned form `MarshalAttribute`. This also allows the existing struct-tag-configured date formatting logic to be applied to the transformed value without the need for re-implementation. This makes it easier to implement custom marshaling logic, but it may be harder to document and understand. A similar solution may be achievable for the unmarshaling case, but hasn't been included here.