### PR TITLE
Introduce nullable types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.21', '1.20', '1.19', '1.18', '1.17', '1.11' ]
+        go: [ '1.21', '1.20', '1.19', '1.18']
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 

--- a/examples/app.go
+++ b/examples/app.go
@@ -96,6 +96,28 @@ func exerciseHandler() {
 	fmt.Println(buf.String())
 	fmt.Println("============== end raw jsonapi response =============")
 
+	// update
+	blog.UnsettableTime = jsonapi.NewNullableAttrWithValue[time.Time](time.Now())
+	in = bytes.NewBuffer(nil)
+	jsonapi.MarshalOnePayloadEmbedded(in, blog)
+
+	req, _ = http.NewRequest(http.MethodPatch, "/blogs", in)
+
+	req.Header.Set(headerAccept, jsonapi.MediaType)
+
+	w = httptest.NewRecorder()
+
+	fmt.Println("============ start update ===========")
+	http.DefaultServeMux.ServeHTTP(w, req)
+	fmt.Println("============ stop update ===========")
+
+	buf = bytes.NewBuffer(nil)
+	io.Copy(buf, w.Body)
+
+	fmt.Println("============ jsonapi response from update ===========")
+	fmt.Println(buf.String())
+	fmt.Println("============== end raw jsonapi response =============")
+
 	// echo
 	blogs := []interface{}{
 		fixtureBlogCreate(1),

--- a/examples/fixtures.go
+++ b/examples/fixtures.go
@@ -1,6 +1,8 @@
 package main
 
-import "time"
+import (
+	"time"
+)
 
 func fixtureBlogCreate(i int) *Blog {
 	return &Blog{

--- a/examples/handler.go
+++ b/examples/handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -25,6 +26,8 @@ func (h *ExampleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPost:
 		methodHandler = h.createBlog
+	case http.MethodPatch:
+		methodHandler = h.updateBlog
 	case http.MethodPut:
 		methodHandler = h.echoBlogs
 	case http.MethodGet:
@@ -50,6 +53,28 @@ func (h *ExampleHandler) createBlog(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// ...do stuff with your blog...
+
+	w.WriteHeader(http.StatusCreated)
+	w.Header().Set(headerContentType, jsonapi.MediaType)
+
+	if err := jsonapiRuntime.MarshalPayload(w, blog); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (h *ExampleHandler) updateBlog(w http.ResponseWriter, r *http.Request) {
+	jsonapiRuntime := jsonapi.NewRuntime().Instrument("blogs.update")
+
+	blog := new(Blog)
+
+	if err := jsonapiRuntime.UnmarshalPayload(r.Body, blog); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Println(blog)
 
 	// ...do stuff with your blog...
 

--- a/examples/models.go
+++ b/examples/models.go
@@ -9,13 +9,14 @@ import (
 
 // Blog is a model representing a blog site
 type Blog struct {
-	ID            int       `jsonapi:"primary,blogs"`
-	Title         string    `jsonapi:"attr,title"`
-	Posts         []*Post   `jsonapi:"relation,posts"`
-	CurrentPost   *Post     `jsonapi:"relation,current_post"`
-	CurrentPostID int       `jsonapi:"attr,current_post_id"`
-	CreatedAt     time.Time `jsonapi:"attr,created_at"`
-	ViewCount     int       `jsonapi:"attr,view_count"`
+	ID             int                             `jsonapi:"primary,blogs"`
+	Title          string                          `jsonapi:"attr,title"`
+	Posts          []*Post                         `jsonapi:"relation,posts"`
+	CurrentPost    *Post                           `jsonapi:"relation,current_post"`
+	CurrentPostID  int                             `jsonapi:"attr,current_post_id"`
+	CreatedAt      time.Time                       `jsonapi:"attr,created_at"`
+	UnsettableTime jsonapi.NullableAttr[time.Time] `jsonapi:"attr,unsettable_time,rfc3339,omitempty"`
+	ViewCount      int                             `jsonapi:"attr,view_count"`
 }
 
 // Post is a model representing a post on a blog

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/hashicorp/jsonapi
+
+go 1.18

--- a/models_test.go
+++ b/models_test.go
@@ -35,6 +35,15 @@ type TimestampModel struct {
 	RFC3339P *time.Time `jsonapi:"attr,rfc3339p,rfc3339"`
 }
 
+type WithNullables struct {
+	ID          int                 `jsonapi:"primary,with-nullables"`
+	Name        string              `jsonapi:"attr,name"`
+	IntTime     Nullable[time.Time] `jsonapi:"attr,int_time,omitempty"`
+	RFC3339Time Nullable[time.Time] `jsonapi:"attr,rfc3339_time,rfc3339,omitempty"`
+	ISO8601Time Nullable[time.Time] `jsonapi:"attr,iso8601_time,iso8601,omitempty"`
+	Bool        Nullable[bool]      `jsonapi:"attr,bool,omitempty"`
+}
+
 type Car struct {
 	ID    *string `jsonapi:"primary,cars"`
 	Make  *string `jsonapi:"attr,make,omitempty"`

--- a/models_test.go
+++ b/models_test.go
@@ -35,13 +35,13 @@ type TimestampModel struct {
 	RFC3339P *time.Time `jsonapi:"attr,rfc3339p,rfc3339"`
 }
 
-type WithNullables struct {
-	ID          int                 `jsonapi:"primary,with-nullables"`
-	Name        string              `jsonapi:"attr,name"`
-	IntTime     Nullable[time.Time] `jsonapi:"attr,int_time,omitempty"`
-	RFC3339Time Nullable[time.Time] `jsonapi:"attr,rfc3339_time,rfc3339,omitempty"`
-	ISO8601Time Nullable[time.Time] `jsonapi:"attr,iso8601_time,iso8601,omitempty"`
-	Bool        Nullable[bool]      `jsonapi:"attr,bool,omitempty"`
+type WithNullableAttrs struct {
+	ID          int                     `jsonapi:"primary,with-nullables"`
+	Name        string                  `jsonapi:"attr,name"`
+	IntTime     NullableAttr[time.Time] `jsonapi:"attr,int_time,omitempty"`
+	RFC3339Time NullableAttr[time.Time] `jsonapi:"attr,rfc3339_time,rfc3339,omitempty"`
+	ISO8601Time NullableAttr[time.Time] `jsonapi:"attr,iso8601_time,iso8601,omitempty"`
+	Bool        NullableAttr[bool]      `jsonapi:"attr,bool,omitempty"`
 }
 
 type Car struct {

--- a/nullable.go
+++ b/nullable.go
@@ -73,7 +73,7 @@ func (t NullableAttr[T]) IsNull() bool {
 	return foundNull
 }
 
-// SetNull indicate that the field was sent, and had a value of `null`
+// SetNull sets the value to an explicit `null`
 func (t *NullableAttr[T]) SetNull() {
 	var empty T
 	*t = map[bool]T{false: empty}
@@ -84,7 +84,7 @@ func (t NullableAttr[T]) IsSpecified() bool {
 	return len(t) != 0
 }
 
-// SetUnspecified indicate whether the field was sent
+// SetUnspecified sets the value to be absent from the serialized payload
 func (t *NullableAttr[T]) SetUnspecified() {
 	*t = map[bool]T{}
 }

--- a/nullable.go
+++ b/nullable.go
@@ -2,14 +2,8 @@ package jsonapi
 
 import (
 	"errors"
-	"reflect"
 	"time"
 )
-
-var SupportedNullableTypes = map[string]reflect.Value{
-	"bool":      reflect.ValueOf(false),
-	"time.Time": reflect.ValueOf(time.Time{}),
-}
 
 // Nullable is a generic type, which implements a field that can be one of three states:
 //

--- a/nullable.go
+++ b/nullable.go
@@ -5,13 +5,13 @@ import (
 	"time"
 )
 
-// Nullable is a generic type, which implements a field that can be one of three states:
+// NullableAttr is a generic type, which implements a field that can be one of three states:
 //
 // - field is not set in the request
 // - field is explicitly set to `null` in the request
 // - field is explicitly set to a valid value in the request
 //
-// Nullable is intended to be used with JSON marshalling and unmarshalling.
+// NullableAttr is intended to be used with JSON marshalling and unmarshalling.
 // This is generally useful for PATCH requests, where attributes with zero
 // values are intentionally not marshaled into the request payload so that
 // existing attribute values are not overwritten.
@@ -22,32 +22,31 @@ import (
 // - map[false]T means an explicit null was provided
 // - nil or zero map means the field was not provided
 //
-// If the field is expected to be optional, add the `omitempty` JSON tags. Do NOT use `*Nullable`!
+// If the field is expected to be optional, add the `omitempty` JSON tags. Do NOT use `*NullableAttr`!
 //
 // Adapted from https://www.jvt.me/posts/2024/01/09/go-json-nullable/
+type NullableAttr[T any] map[bool]T
 
-type Nullable[T any] map[bool]T
-
-// NewNullableWithValue is a convenience helper to allow constructing a
-// Nullable with a given value, for instance to construct a field inside a
+// NewNullableAttrWithValue is a convenience helper to allow constructing a
+// NullableAttr with a given value, for instance to construct a field inside a
 // struct without introducing an intermediate variable.
-func NewNullableWithValue[T any](t T) Nullable[T] {
-	var n Nullable[T]
+func NewNullableAttrWithValue[T any](t T) NullableAttr[T] {
+	var n NullableAttr[T]
 	n.Set(t)
 	return n
 }
 
-// NewNullNullable is a convenience helper to allow constructing a Nullable with
+// NewNullNullableAttr is a convenience helper to allow constructing a NullableAttr with
 // an explicit `null`, for instance to construct a field inside a struct
 // without introducing an intermediate variable
-func NewNullNullable[T any]() Nullable[T] {
-	var n Nullable[T]
+func NewNullNullableAttr[T any]() NullableAttr[T] {
+	var n NullableAttr[T]
 	n.SetNull()
 	return n
 }
 
 // Get retrieves the underlying value, if present, and returns an error if the value was not present
-func (t Nullable[T]) Get() (T, error) {
+func (t NullableAttr[T]) Get() (T, error) {
 	var empty T
 	if t.IsNull() {
 		return empty, errors.New("value is null")
@@ -59,49 +58,49 @@ func (t Nullable[T]) Get() (T, error) {
 }
 
 // Set sets the underlying value to a given value
-func (t *Nullable[T]) Set(value T) {
+func (t *NullableAttr[T]) Set(value T) {
 	*t = map[bool]T{true: value}
 }
 
 // Set sets the underlying value to a given value
-func (t *Nullable[T]) SetInterface(value interface{}) {
+func (t *NullableAttr[T]) SetInterface(value interface{}) {
 	t.Set(value.(T))
 }
 
 // IsNull indicate whether the field was sent, and had a value of `null`
-func (t Nullable[T]) IsNull() bool {
+func (t NullableAttr[T]) IsNull() bool {
 	_, foundNull := t[false]
 	return foundNull
 }
 
 // SetNull indicate that the field was sent, and had a value of `null`
-func (t *Nullable[T]) SetNull() {
+func (t *NullableAttr[T]) SetNull() {
 	var empty T
 	*t = map[bool]T{false: empty}
 }
 
 // IsSpecified indicates whether the field was sent
-func (t Nullable[T]) IsSpecified() bool {
+func (t NullableAttr[T]) IsSpecified() bool {
 	return len(t) != 0
 }
 
 // SetUnspecified indicate whether the field was sent
-func (t *Nullable[T]) SetUnspecified() {
+func (t *NullableAttr[T]) SetUnspecified() {
 	*t = map[bool]T{}
 }
 
-func NullableBool(v bool) Nullable[bool] {
-	return NewNullableWithValue[bool](v)
+func NullableBool(v bool) NullableAttr[bool] {
+	return NewNullableAttrWithValue[bool](v)
 }
 
-func NullBool() Nullable[bool] {
-	return NewNullNullable[bool]()
+func NullBool() NullableAttr[bool] {
+	return NewNullNullableAttr[bool]()
 }
 
-func NullableTime(v time.Time) Nullable[time.Time] {
-	return NewNullableWithValue[time.Time](v)
+func NullableTime(v time.Time) NullableAttr[time.Time] {
+	return NewNullableAttrWithValue[time.Time](v)
 }
 
-func NullTime() Nullable[time.Time] {
-	return NewNullNullable[time.Time]()
+func NullTime() NullableAttr[time.Time] {
+	return NewNullNullableAttr[time.Time]()
 }

--- a/nullable.go
+++ b/nullable.go
@@ -1,0 +1,113 @@
+package jsonapi
+
+import (
+	"errors"
+	"reflect"
+	"time"
+)
+
+var supportedNullableTypes = map[string]reflect.Value{
+	"bool":      reflect.ValueOf(false),
+	"time.Time": reflect.ValueOf(time.Time{}),
+}
+
+// Nullable is a generic type, which implements a field that can be one of three states:
+//
+// - field is not set in the request
+// - field is explicitly set to `null` in the request
+// - field is explicitly set to a valid value in the request
+//
+// Nullable is intended to be used with JSON marshalling and unmarshalling.
+// This is generally useful for PATCH requests, where attributes with zero
+// values are intentionally not marshaled into the request payload so that
+// existing attribute values are not overwritten.
+//
+// Internal implementation details:
+//
+// - map[true]T means a value was provided
+// - map[false]T means an explicit null was provided
+// - nil or zero map means the field was not provided
+//
+// If the field is expected to be optional, add the `omitempty` JSON tags. Do NOT use `*Nullable`!
+//
+// Adapted from https://www.jvt.me/posts/2024/01/09/go-json-nullable/
+
+type Nullable[T any] map[bool]T
+
+// NewNullableWithValue is a convenience helper to allow constructing a
+// Nullable with a given value, for instance to construct a field inside a
+// struct without introducing an intermediate variable.
+func NewNullableWithValue[T any](t T) Nullable[T] {
+	var n Nullable[T]
+	n.Set(t)
+	return n
+}
+
+// NewNullNullable is a convenience helper to allow constructing a Nullable with
+// an explicit `null`, for instance to construct a field inside a struct
+// without introducing an intermediate variable
+func NewNullNullable[T any]() Nullable[T] {
+	var n Nullable[T]
+	n.SetNull()
+	return n
+}
+
+// Get retrieves the underlying value, if present, and returns an error if the value was not present
+func (t Nullable[T]) Get() (T, error) {
+	var empty T
+	if t.IsNull() {
+		return empty, errors.New("value is null")
+	}
+	if !t.IsSpecified() {
+		return empty, errors.New("value is not specified")
+	}
+	return t[true], nil
+}
+
+// Set sets the underlying value to a given value
+func (t *Nullable[T]) Set(value T) {
+	*t = map[bool]T{true: value}
+}
+
+// Set sets the underlying value to a given value
+func (t *Nullable[T]) SetInterface(value interface{}) {
+	t.Set(value.(T))
+}
+
+// IsNull indicate whether the field was sent, and had a value of `null`
+func (t Nullable[T]) IsNull() bool {
+	_, foundNull := t[false]
+	return foundNull
+}
+
+// SetNull indicate that the field was sent, and had a value of `null`
+func (t *Nullable[T]) SetNull() {
+	var empty T
+	*t = map[bool]T{false: empty}
+}
+
+// IsSpecified indicates whether the field was sent
+func (t Nullable[T]) IsSpecified() bool {
+	return len(t) != 0
+}
+
+// SetUnspecified indicate whether the field was sent
+func (t *Nullable[T]) SetUnspecified() {
+	*t = map[bool]T{}
+}
+
+func NullableBool(v bool) Nullable[bool] {
+	return NewNullableWithValue[bool](v)
+}
+
+func NullBool() Nullable[bool] {
+	return NewNullNullable[bool]()
+}
+
+func NullableTime(v time.Time) Nullable[time.Time] {
+	return NewNullableWithValue[time.Time](v)
+}
+
+func NullTime() Nullable[time.Time] {
+	return NewNullNullable[time.Time]()
+}

--- a/nullable.go
+++ b/nullable.go
@@ -2,7 +2,6 @@ package jsonapi
 
 import (
 	"errors"
-	"time"
 )
 
 // NullableAttr is a generic type, which implements a field that can be one of three states:
@@ -87,20 +86,4 @@ func (t NullableAttr[T]) IsSpecified() bool {
 // SetUnspecified sets the value to be absent from the serialized payload
 func (t *NullableAttr[T]) SetUnspecified() {
 	*t = map[bool]T{}
-}
-
-func NullableBool(v bool) NullableAttr[bool] {
-	return NewNullableAttrWithValue[bool](v)
-}
-
-func NullBool() NullableAttr[bool] {
-	return NewNullNullableAttr[bool]()
-}
-
-func NullableTime(v time.Time) NullableAttr[time.Time] {
-	return NewNullableAttrWithValue[time.Time](v)
-}
-
-func NullTime() NullableAttr[time.Time] {
-	return NewNullNullableAttr[time.Time]()
 }

--- a/nullable.go
+++ b/nullable.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-var supportedNullableTypes = map[string]reflect.Value{
+var SupportedNullableTypes = map[string]reflect.Value{
 	"bool":      reflect.ValueOf(false),
 	"time.Time": reflect.ValueOf(time.Time{}),
 }

--- a/request.go
+++ b/request.go
@@ -678,7 +678,7 @@ func handleNullable(
 	var rgx = regexp.MustCompile(`\[(.*)\]`)
 	rs := rgx.FindStringSubmatch(fieldValue.Type().Name())
 
-	attrVal, err := unmarshalAttribute(attribute, args, structField, supportedNullableTypes[rs[1]])
+	attrVal, err := unmarshalAttribute(attribute, args, structField, SupportedNullableTypes[rs[1]])
 	if err != nil {
 		return reflect.ValueOf(nil), err
 	}

--- a/request.go
+++ b/request.go
@@ -668,10 +668,8 @@ func handleNullable(
 	structField reflect.StructField,
 	fieldValue reflect.Value) (reflect.Value, error) {
 
-	if a, ok := attribute.(string); ok {
-		if bytes.Equal([]byte(a), []byte("null")) {
-			return reflect.ValueOf(nil), nil
-		}
+	if a, ok := attribute.(string); ok && a == "null" {
+		return reflect.ValueOf(nil), nil
 	}
 
 	innerType := fieldValue.Type().Elem()
@@ -682,7 +680,7 @@ func handleNullable(
 		return reflect.ValueOf(nil), err
 	}
 
-	fieldValue.Set(reflect.MakeMap(fieldValue.Type()))
+	fieldValue.Set(reflect.MakeMapWithSize(fieldValue.Type(), 1))
 	fieldValue.SetMapIndex(reflect.ValueOf(true), attrVal)
 
 	return fieldValue, nil

--- a/request.go
+++ b/request.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -675,10 +674,10 @@ func handleNullable(
 		}
 	}
 
-	var rgx = regexp.MustCompile(`\[(.*)\]`)
-	rs := rgx.FindStringSubmatch(fieldValue.Type().Name())
+	innerType := fieldValue.Type().Elem()
+	zeroValue := reflect.Zero(innerType)
 
-	attrVal, err := unmarshalAttribute(attribute, args, structField, SupportedNullableTypes[rs[1]])
+	attrVal, err := unmarshalAttribute(attribute, args, structField, zeroValue)
 	if err != nil {
 		return reflect.ValueOf(nil), err
 	}

--- a/request.go
+++ b/request.go
@@ -589,8 +589,8 @@ func unmarshalAttribute(
 	value = reflect.ValueOf(attribute)
 	fieldType := structField.Type
 
-	// Handle Nullable[T]
-	if strings.HasPrefix(fieldValue.Type().Name(), "Nullable[") {
+	// Handle NullableAttr[T]
+	if strings.HasPrefix(fieldValue.Type().Name(), "NullableAttr[") {
 		value, err = handleNullable(attribute, args, structField, fieldValue)
 		return
 	}
@@ -746,7 +746,7 @@ func handleTime(attribute interface{}, args []string, fieldValue reflect.Value) 
 		return reflect.ValueOf(time.Now()), ErrInvalidTime
 	}
 
-	t := time.Unix(at, 0).UTC()
+	t := time.Unix(at, 0)
 
 	return reflect.ValueOf(t), nil
 }

--- a/request_test.go
+++ b/request_test.go
@@ -300,6 +300,88 @@ func TestStringPointerField(t *testing.T) {
 	}
 }
 
+func TestUnmarshalNullableTime(t *testing.T) {
+	aTime := time.Date(2016, 8, 17, 8, 27, 12, 23849, time.UTC)
+
+	out := new(WithNullables)
+
+	attrs := map[string]interface{}{
+		"name":         "Name",
+		"int_time":     aTime.Unix(),
+		"rfc3339_time": aTime.Format(time.RFC3339),
+		"iso8601_time": aTime.Format(iso8601TimeFormat),
+	}
+
+	if err := UnmarshalPayload(samplePayloadWithNullables(attrs), out); err != nil {
+		t.Fatal(err)
+	}
+
+	if out.IntTime == nil {
+		t.Fatal("Was not expecting a nil pointer for out.IntTime")
+	}
+
+	timeVal, err := out.IntTime.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected, actual := aTime, timeVal; expected.Equal(actual) {
+		t.Fatalf("Was expecting int_time to be `%s`, got `%s`", expected, actual)
+	}
+
+	timeVal, err = out.IntTime.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if out.RFC3339Time == nil {
+		t.Fatal("Was not expecting a nil pointer for out.RFC3339Time")
+	}
+	if expected, actual := aTime, timeVal; expected.Equal(actual) {
+		t.Fatalf("Was expecting descript to be `%s`, got `%s`", expected, actual)
+	}
+
+	timeVal, err = out.IntTime.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if out.ISO8601Time == nil {
+		t.Fatal("Was not expecting a nil pointer for out.ISO8601Time")
+	}
+	if expected, actual := aTime, timeVal; expected.Equal(actual) {
+		t.Fatalf("Was expecting descript to be `%s`, got `%s`", expected, actual)
+	}
+}
+
+func TestUnmarshalNullableBool(t *testing.T) {
+	out := new(WithNullables)
+
+	aBool := false
+
+	attrs := map[string]interface{}{
+		"name": "Name",
+		"bool": aBool,
+	}
+
+	if err := UnmarshalPayload(samplePayloadWithNullables(attrs), out); err != nil {
+		t.Fatal(err)
+	}
+
+	if out.Bool == nil {
+		t.Fatal("Was not expecting a nil pointer for out.Bool")
+	}
+
+	boolVal, err := out.Bool.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected, actual := aBool, boolVal; expected != actual {
+		t.Fatalf("Was expecting bool to be `%t`, got `%t`", expected, actual)
+	}
+}
+
 func TestMalformedTag(t *testing.T) {
 	out := new(BadModel)
 	err := UnmarshalPayload(samplePayload(), out)
@@ -1416,6 +1498,21 @@ func sampleWithPointerPayload(m map[string]interface{}) io.Reader {
 		Data: &Node{
 			ID:         "2",
 			Type:       "with-pointers",
+			Attributes: m,
+		},
+	}
+
+	out := bytes.NewBuffer(nil)
+	json.NewEncoder(out).Encode(payload)
+
+	return out
+}
+
+func samplePayloadWithNullables(m map[string]interface{}) io.Reader {
+	payload := &OnePayload{
+		Data: &Node{
+			ID:         "5",
+			Type:       "with-nullables",
 			Attributes: m,
 		},
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -303,7 +303,7 @@ func TestStringPointerField(t *testing.T) {
 func TestUnmarshalNullableTime(t *testing.T) {
 	aTime := time.Date(2016, 8, 17, 8, 27, 12, 23849, time.UTC)
 
-	out := new(WithNullables)
+	out := new(WithNullableAttrs)
 
 	attrs := map[string]interface{}{
 		"name":         "Name",
@@ -312,7 +312,7 @@ func TestUnmarshalNullableTime(t *testing.T) {
 		"iso8601_time": aTime.Format(iso8601TimeFormat),
 	}
 
-	if err := UnmarshalPayload(samplePayloadWithNullables(attrs), out); err != nil {
+	if err := UnmarshalPayload(samplePayloadWithNullableAttrs(attrs), out); err != nil {
 		t.Fatal(err)
 	}
 
@@ -355,7 +355,7 @@ func TestUnmarshalNullableTime(t *testing.T) {
 }
 
 func TestUnmarshalNullableBool(t *testing.T) {
-	out := new(WithNullables)
+	out := new(WithNullableAttrs)
 
 	aBool := false
 
@@ -364,7 +364,7 @@ func TestUnmarshalNullableBool(t *testing.T) {
 		"bool": aBool,
 	}
 
-	if err := UnmarshalPayload(samplePayloadWithNullables(attrs), out); err != nil {
+	if err := UnmarshalPayload(samplePayloadWithNullableAttrs(attrs), out); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1508,7 +1508,7 @@ func sampleWithPointerPayload(m map[string]interface{}) io.Reader {
 	return out
 }
 
-func samplePayloadWithNullables(m map[string]interface{}) io.Reader {
+func samplePayloadWithNullableAttrs(m map[string]interface{}) io.Reader {
 	payload := &OnePayload{
 		Data: &Node{
 			ID:         "5",

--- a/response.go
+++ b/response.go
@@ -331,6 +331,22 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 				node.Attributes = make(map[string]interface{})
 			}
 
+			// Handle Nullable[T]
+			if strings.HasPrefix(fieldValue.Type().Name(), "Nullable[") {
+				// handle unspecified
+				if fieldValue.IsNil() {
+					continue
+				}
+
+				// handle null
+				if fieldValue.MapIndex(reflect.ValueOf(false)).IsValid() {
+					continue
+				}
+
+				// handle value
+				fieldValue = fieldValue.MapIndex(reflect.ValueOf(true))
+			}
+
 			if fieldValue.Type() == reflect.TypeOf(time.Time{}) {
 				t := fieldValue.Interface().(time.Time)
 

--- a/response.go
+++ b/response.go
@@ -332,7 +332,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 			}
 
 			// Handle Nullable[T]
-			if strings.HasPrefix(fieldValue.Type().Name(), "Nullable[") {
+			if strings.HasPrefix(fieldValue.Type().Name(), "NullableAttr[") {
 				// handle unspecified
 				if fieldValue.IsNil() {
 					continue

--- a/response_test.go
+++ b/response_test.go
@@ -820,6 +820,154 @@ func TestMarshal_Times(t *testing.T) {
 	}
 }
 
+func TestCustomMarshal_Time(t *testing.T) {
+	aTime := time.Date(2016, 8, 17, 8, 27, 12, 23849, time.UTC)
+
+	for _, tc := range []struct {
+		desc         string
+		input        *WithNullables
+		verification func(data map[string]interface{}) error
+	}{
+		{
+			desc: "time_nil",
+			input: &WithNullables{
+				ID:          5,
+				RFC3339Time: nil,
+			},
+			verification: func(root map[string]interface{}) error {
+				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["rfc3339_time"]
+				if got, want := v, (interface{})(nil); got != want {
+					return fmt.Errorf("got %v, want %v", got, want)
+				}
+				return nil
+			},
+		},
+		{
+			desc: "time_value_rfc3339",
+			input: &WithNullables{
+				ID:          5,
+				RFC3339Time: NullableTime(aTime),
+			},
+			verification: func(root map[string]interface{}) error {
+				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["rfc3339_time"].(string)
+				if got, want := v, aTime.Format(time.RFC3339); got != want {
+					return fmt.Errorf("got %v, want %v", got, want)
+				}
+				return nil
+			},
+		},
+		{
+			desc: "time_value_iso8601",
+			input: &WithNullables{
+				ID:          5,
+				ISO8601Time: NullableTime(aTime),
+			},
+			verification: func(root map[string]interface{}) error {
+				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["iso8601_time"].(string)
+				if got, want := v, aTime.Format(iso8601TimeFormat); got != want {
+					return fmt.Errorf("got %v, want %v", got, want)
+				}
+				return nil
+			},
+		},
+		{
+			desc: "time_null_integer",
+			input: &WithNullables{
+				ID:      5,
+				IntTime: NullTime(),
+			},
+			verification: func(root map[string]interface{}) error {
+				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["int_time"]
+				if got, want := v, (interface{})(nil); got != want {
+					return fmt.Errorf("got %v, want %v", got, want)
+				}
+				return nil
+			},
+		}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			out := bytes.NewBuffer(nil)
+			if err := MarshalPayload(out, tc.input); err != nil {
+				t.Fatal(err)
+			}
+			// Use the standard JSON library to traverse the genereated JSON payload.
+			data := map[string]interface{}{}
+			json.Unmarshal(out.Bytes(), &data)
+			if tc.verification != nil {
+				if err := tc.verification(data); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func TestCustomMarshal_Bool(t *testing.T) {
+	aBool := true
+
+	for _, tc := range []struct {
+		desc         string
+		input        *WithNullables
+		verification func(data map[string]interface{}) error
+	}{
+		{
+			desc: "bool_nil",
+			input: &WithNullables{
+				ID:   5,
+				Bool: nil,
+			},
+			verification: func(root map[string]interface{}) error {
+				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["bool"]
+				if got, want := v, (interface{})(nil); got != want {
+					return fmt.Errorf("got %v, want %v", got, want)
+				}
+				return nil
+			},
+		},
+		{
+			desc: "unsetable_value_present",
+			input: &WithNullables{
+				ID:   5,
+				Bool: NullableBool(aBool),
+			},
+			verification: func(root map[string]interface{}) error {
+				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["bool"].(bool)
+				if got, want := v, aBool; got != want {
+					return fmt.Errorf("got %v, want %v", got, want)
+				}
+				return nil
+			},
+		},
+		{
+			desc: "unsetable_nil_value",
+			input: &WithNullables{
+				ID:   5,
+				Bool: NullBool(),
+			},
+			verification: func(root map[string]interface{}) error {
+				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["bool"]
+				if got, want := v, (interface{})(nil); got != want {
+					return fmt.Errorf("got %v, want %v", got, want)
+				}
+				return nil
+			},
+		}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			out := bytes.NewBuffer(nil)
+			if err := MarshalPayload(out, tc.input); err != nil {
+				t.Fatal(err)
+			}
+			// Use the standard JSON library to traverse the genereated JSON payload.
+			data := map[string]interface{}{}
+			json.Unmarshal(out.Bytes(), &data)
+			if tc.verification != nil {
+				if err := tc.verification(data); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func TestSupportsLinkable(t *testing.T) {
 	testModel := &Blog{
 		ID:        5,

--- a/response_test.go
+++ b/response_test.go
@@ -846,7 +846,7 @@ func TestNullableAttr_Time(t *testing.T) {
 			desc: "time_null",
 			input: &WithNullableAttrs{
 				ID:          5,
-				RFC3339Time: NullTime(),
+				RFC3339Time: NewNullNullableAttr[time.Time](),
 			},
 			verification: func(root map[string]interface{}) error {
 				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["rfc3339_time"]
@@ -860,7 +860,7 @@ func TestNullableAttr_Time(t *testing.T) {
 			desc: "time_not_null_rfc3339",
 			input: &WithNullableAttrs{
 				ID:          5,
-				RFC3339Time: NullableTime(aTime),
+				RFC3339Time: NewNullableAttrWithValue[time.Time](aTime),
 			},
 			verification: func(root map[string]interface{}) error {
 				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["rfc3339_time"].(string)
@@ -874,7 +874,7 @@ func TestNullableAttr_Time(t *testing.T) {
 			desc: "time_not_null_iso8601",
 			input: &WithNullableAttrs{
 				ID:          5,
-				ISO8601Time: NullableTime(aTime),
+				ISO8601Time: NewNullableAttrWithValue[time.Time](aTime),
 			},
 			verification: func(root map[string]interface{}) error {
 				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["iso8601_time"].(string)
@@ -888,7 +888,7 @@ func TestNullableAttr_Time(t *testing.T) {
 			desc: "time_not_null_int",
 			input: &WithNullableAttrs{
 				ID:      5,
-				IntTime: NullableTime(aTime),
+				IntTime: NewNullableAttrWithValue[time.Time](aTime),
 			},
 			verification: func(root map[string]interface{}) error {
 				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["int_time"].(float64)
@@ -941,7 +941,7 @@ func TestNullableAttr_Bool(t *testing.T) {
 			desc: "bool_null",
 			input: &WithNullableAttrs{
 				ID:   5,
-				Bool: NullBool(),
+				Bool: NewNullNullableAttr[bool](),
 			},
 			verification: func(root map[string]interface{}) error {
 				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["bool"]
@@ -955,7 +955,7 @@ func TestNullableAttr_Bool(t *testing.T) {
 			desc: "bool_not_null",
 			input: &WithNullableAttrs{
 				ID:   5,
-				Bool: NullableBool(aBool),
+				Bool: NewNullableAttrWithValue[bool](aBool),
 			},
 			verification: func(root map[string]interface{}) error {
 				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["bool"].(bool)

--- a/response_test.go
+++ b/response_test.go
@@ -820,17 +820,17 @@ func TestMarshal_Times(t *testing.T) {
 	}
 }
 
-func TestCustomMarshal_Time(t *testing.T) {
+func TestNullableAttr_Time(t *testing.T) {
 	aTime := time.Date(2016, 8, 17, 8, 27, 12, 23849, time.UTC)
 
 	for _, tc := range []struct {
 		desc         string
-		input        *WithNullables
+		input        *WithNullableAttrs
 		verification func(data map[string]interface{}) error
 	}{
 		{
-			desc: "time_nil",
-			input: &WithNullables{
+			desc: "time_unspecified",
+			input: &WithNullableAttrs{
 				ID:          5,
 				RFC3339Time: nil,
 			},
@@ -843,8 +843,22 @@ func TestCustomMarshal_Time(t *testing.T) {
 			},
 		},
 		{
-			desc: "time_value_rfc3339",
-			input: &WithNullables{
+			desc: "time_null",
+			input: &WithNullableAttrs{
+				ID:          5,
+				RFC3339Time: NullTime(),
+			},
+			verification: func(root map[string]interface{}) error {
+				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["rfc3339_time"]
+				if got, want := v, (interface{})(nil); got != want {
+					return fmt.Errorf("got %v, want %v", got, want)
+				}
+				return nil
+			},
+		},
+		{
+			desc: "time_not_null_rfc3339",
+			input: &WithNullableAttrs{
 				ID:          5,
 				RFC3339Time: NullableTime(aTime),
 			},
@@ -857,8 +871,8 @@ func TestCustomMarshal_Time(t *testing.T) {
 			},
 		},
 		{
-			desc: "time_value_iso8601",
-			input: &WithNullables{
+			desc: "time_not_null_iso8601",
+			input: &WithNullableAttrs{
 				ID:          5,
 				ISO8601Time: NullableTime(aTime),
 			},
@@ -871,14 +885,14 @@ func TestCustomMarshal_Time(t *testing.T) {
 			},
 		},
 		{
-			desc: "time_null_integer",
-			input: &WithNullables{
+			desc: "time_not_null_int",
+			input: &WithNullableAttrs{
 				ID:      5,
-				IntTime: NullTime(),
+				IntTime: NullableTime(aTime),
 			},
 			verification: func(root map[string]interface{}) error {
-				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["int_time"]
-				if got, want := v, (interface{})(nil); got != want {
+				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["int_time"].(float64)
+				if got, want := int64(v), aTime.Unix(); got != want {
 					return fmt.Errorf("got %v, want %v", got, want)
 				}
 				return nil
@@ -901,17 +915,17 @@ func TestCustomMarshal_Time(t *testing.T) {
 	}
 }
 
-func TestCustomMarshal_Bool(t *testing.T) {
+func TestNullableAttr_Bool(t *testing.T) {
 	aBool := true
 
 	for _, tc := range []struct {
 		desc         string
-		input        *WithNullables
+		input        *WithNullableAttrs
 		verification func(data map[string]interface{}) error
 	}{
 		{
-			desc: "bool_nil",
-			input: &WithNullables{
+			desc: "bool_unspecified",
+			input: &WithNullableAttrs{
 				ID:   5,
 				Bool: nil,
 			},
@@ -924,8 +938,22 @@ func TestCustomMarshal_Bool(t *testing.T) {
 			},
 		},
 		{
-			desc: "unsetable_value_present",
-			input: &WithNullables{
+			desc: "bool_null",
+			input: &WithNullableAttrs{
+				ID:   5,
+				Bool: NullBool(),
+			},
+			verification: func(root map[string]interface{}) error {
+				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["bool"]
+				if got, want := v, (interface{})(nil); got != want {
+					return fmt.Errorf("got %v, want %v", got, want)
+				}
+				return nil
+			},
+		},
+		{
+			desc: "bool_not_null",
+			input: &WithNullableAttrs{
 				ID:   5,
 				Bool: NullableBool(aBool),
 			},
@@ -937,20 +965,7 @@ func TestCustomMarshal_Bool(t *testing.T) {
 				return nil
 			},
 		},
-		{
-			desc: "unsetable_nil_value",
-			input: &WithNullables{
-				ID:   5,
-				Bool: NullBool(),
-			},
-			verification: func(root map[string]interface{}) error {
-				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["bool"]
-				if got, want := v, (interface{})(nil); got != want {
-					return fmt.Errorf("got %v, want %v", got, want)
-				}
-				return nil
-			},
-		}} {
+	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			out := bytes.NewBuffer(nil)
 			if err := MarshalPayload(out, tc.input); err != nil {


### PR DESCRIPTION
This PR introduces a `Nullable[T]` type natively to `jsonapi` that can be used to differentiate between null and unspecified values in payloads.

This method does not make use of, or solve for, custom marshaling and unmarshaling. Relying on the low level interfaces in `encoding/json` doesn't allow for handling the inner values of `Nullable[T]` within the context of the struct tags defined on the DTO. Processing `Nullable`s natively when marshaling & unmarshaling allows us to preserve the nested struct support included in this library and to use all of its special case handling for parsing values such as `time.Time` based on struct tag values.

## External links

- [JIRA](https://hashicorp.atlassian.net/browse/TF-10307)
- [downsteam go-tfe PR](https://github.com/hashicorp/go-tfe/pull/786)