### PR TITLE
fix: make Nullable handle significant null marshaling properly

### DIFF
--- a/response.go
+++ b/response.go
@@ -340,11 +340,13 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 
 				// handle null
 				if fieldValue.MapIndex(reflect.ValueOf(false)).IsValid() {
+					node.Attributes[args[1]] = json.RawMessage("null")
 					continue
-				}
+				} else {
 
-				// handle value
-				fieldValue = fieldValue.MapIndex(reflect.ValueOf(true))
+					// handle value
+					fieldValue = fieldValue.MapIndex(reflect.ValueOf(true))
+				}
 			}
 
 			if fieldValue.Type() == reflect.TypeOf(time.Time{}) {

--- a/response_test.go
+++ b/response_test.go
@@ -835,8 +835,9 @@ func TestNullableAttr_Time(t *testing.T) {
 				RFC3339Time: nil,
 			},
 			verification: func(root map[string]interface{}) error {
-				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["rfc3339_time"]
-				if got, want := v, (interface{})(nil); got != want {
+				_, ok := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["rfc3339_time"]
+
+				if got, want := ok, false; got != want {
 					return fmt.Errorf("got %v, want %v", got, want)
 				}
 				return nil
@@ -849,8 +850,9 @@ func TestNullableAttr_Time(t *testing.T) {
 				RFC3339Time: NewNullNullableAttr[time.Time](),
 			},
 			verification: func(root map[string]interface{}) error {
-				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["rfc3339_time"]
-				if got, want := v, (interface{})(nil); got != want {
+				_, ok := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["rfc3339_time"]
+
+				if got, want := ok, true; got != want {
 					return fmt.Errorf("got %v, want %v", got, want)
 				}
 				return nil
@@ -930,8 +932,9 @@ func TestNullableAttr_Bool(t *testing.T) {
 				Bool: nil,
 			},
 			verification: func(root map[string]interface{}) error {
-				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["bool"]
-				if got, want := v, (interface{})(nil); got != want {
+				_, ok := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["bool"]
+
+				if got, want := ok, false; got != want {
 					return fmt.Errorf("got %v, want %v", got, want)
 				}
 				return nil
@@ -944,8 +947,9 @@ func TestNullableAttr_Bool(t *testing.T) {
 				Bool: NewNullNullableAttr[bool](),
 			},
 			verification: func(root map[string]interface{}) error {
-				v := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["bool"]
-				if got, want := v, (interface{})(nil); got != want {
+				_, ok := root["data"].(map[string]interface{})["attributes"].(map[string]interface{})["bool"]
+
+				if got, want := ok, true; got != want {
 					return fmt.Errorf("got %v, want %v", got, want)
 				}
 				return nil


### PR DESCRIPTION
This PR fixes some broken behavior with the `Nullable` generic type that surfaced when trying to put it into use.  Significant nulls were not being marshaled properly, and the payloads were being created as if the attributes were unspecified. The offending code has been fixed and test cases have been updated.

The tests that existed before this PR did not accurately test the "significant null" marshaling case. The tests have been updated and the functionality is now working through the entire workspaces go-tfe integration test case.