### PR TITLE
add 'source' to error object

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -42,8 +42,23 @@ type ErrorObject struct {
 	// Code is an application-specific error code, expressed as a string value.
 	Code string `json:"code,omitempty"`
 
+	// Source is an object containing references to the primary source of the error.
+	Source *ErrorSource `json:"source,omitempty"`
+
 	// Meta is an object containing non-standard meta-information about the error.
 	Meta *map[string]interface{} `json:"meta,omitempty"`
+}
+
+// ErrorSource is an object containing references to the primary source of the error.
+type ErrorSource struct {
+	// Pointer is a string indicating the value in the request document that caused the error.
+	Pointer string `json:"pointer,omitempty"`
+
+	// Parameter is a string indicating which query or path parameter caused the error.
+	Parameter string `json:"parameter,omitempty"`
+
+	// Header is a string indicating the name of a single request header which caused the error.
+	Header string `json:"header,omitempty"`
 }
 
 // Error implements the `Error` interface.

--- a/errors.go
+++ b/errors.go
@@ -50,8 +50,9 @@ type ErrorObject struct {
 }
 
 // ErrorSource is an object containing references to the primary source of the error.
+// Only one field should be populated depending on the source of the error.
 type ErrorSource struct {
-	// Pointer is a string indicating the value in the request document that caused the error.
+	// Pointer is a JSON Pointer (RFC6901) indicating the value in the request document that caused the error.
 	Pointer string `json:"pointer,omitempty"`
 
 	// Parameter is a string indicating which query or path parameter caused the error.

--- a/errors_test.go
+++ b/errors_test.go
@@ -28,9 +28,9 @@ func TestMarshalErrorsWritesTheExpectedPayload(t *testing.T) {
 	}{
 		{
 			Title: "TestFieldsAreSerializedAsNeeded",
-			In:    []*ErrorObject{{ID: "0", Title: "Test title.", Detail: "Test detail", Status: "400", Code: "E1100"}},
+			In:    []*ErrorObject{{ID: "0", Title: "Test title.", Detail: "Test detail", Status: "400", Code: "E1100", Source: &ErrorSource{Pointer: "title"}}},
 			Out: map[string]interface{}{"errors": []interface{}{
-				map[string]interface{}{"id": "0", "title": "Test title.", "detail": "Test detail", "status": "400", "code": "E1100"},
+				map[string]interface{}{"id": "0", "title": "Test title.", "detail": "Test detail", "status": "400", "code": "E1100", "source": map[string]interface{}{"pointer": "title"}},
 			}},
 		},
 		{


### PR DESCRIPTION
Adds `source` to ErrorObject as described in the [specification](https://jsonapi.org/format/#errors).