### PR TITLE
Add an ignore annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,13 @@ A field annotated with `links` will have the links members of the request unmars
 that this field should _always_ be annotated with `omitempty`, as marshaling of links members is
 instead handled by the `Linkable` interface (see `Links` below).
 
+#### `-` (Ignore)
+```
+`jsonapi:"-"`
+```
+
+A field annotated with `-` will never be marshaled or unmarshaled.
+
 ## Methods Reference
 
 **All `Marshal` and `Unmarshal` methods expect pointers to struct
@@ -422,7 +429,7 @@ attribute values of any type.
 
 In the example below, a payload is presented for a fictitious API that makes use
 of significant `null` values. Once enabled, the `UnsettableTime` setting can
-only be disabled by updating it to a `null` value. 
+only be disabled by updating it to a `null` value.
 
 The payload struct below makes use of a `NullableAttr` with an inner `time.Time`
 to allow this behavior:

--- a/constants.go
+++ b/constants.go
@@ -12,6 +12,7 @@ const (
 	annotationOmitEmpty    = "omitempty"
 	annotationISO8601      = "iso8601"
 	annotationRFC3339      = "rfc3339"
+	annotationIgnore       = "-"
 	annotationSeparator    = ","
 
 	iso8601TimeFormat = "2006-01-02T15:04:05Z"

--- a/request.go
+++ b/request.go
@@ -253,9 +253,16 @@ func getStructTags(field reflect.StructField) ([]string, error) {
 
 	annotation := args[0]
 
-	if (annotation == annotationClientID && len(args) != 1) ||
-		(annotation != annotationClientID && len(args) < 2) {
-		return nil, ErrBadJSONAPIStructTag
+	switch annotation {
+	case annotationClientID:
+	case annotationIgnore:
+		if len(args) != 1 {
+			return nil, ErrBadJSONAPIStructTag
+		}
+	default:
+		if len(args) < 2 {
+			return nil, ErrBadJSONAPIStructTag
+		}
 	}
 
 	return args, nil
@@ -326,7 +333,10 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 		}
 		annotation := args[0]
 
-		if annotation == annotationPrimary {
+		if annotation == annotationIgnore {
+			// Do Nothing
+			continue
+		} else if annotation == annotationPrimary {
 			// Check the JSON API Type
 			if data.Type != args[1] {
 				er = fmt.Errorf(

--- a/request_test.go
+++ b/request_test.go
@@ -478,6 +478,54 @@ func TestUnmarshalSetsAttrs(t *testing.T) {
 	}
 }
 
+func TestUnmarshalWithIgnoreAnnotation(t *testing.T) {
+	// This test asserts similar to unmarshalSamplePayload but uses a model
+	// with almost all attributes ignored
+	type BlogWithIgnore struct {
+		ID            int       `jsonapi:"primary,blogs"`
+		ClientID      string    `jsonapi:"client-id"`
+		Title         string    `jsonapi:"-"`
+		Posts         []*Post   `jsonapi:"-"`
+		CurrentPost   *Post     `jsonapi:"-"`
+		CurrentPostID int       `jsonapi:"-"`
+		CreatedAt     time.Time `jsonapi:"-"`
+		ViewCount     int       `jsonapi:"-"`
+
+		Links Links `jsonapi:"-"`
+	}
+
+	in := samplePayload()
+	out := new(BlogWithIgnore)
+
+	if err := UnmarshalPayload(in, out); err != nil {
+		t.Fatal(err)
+	}
+
+	if out.Title != "" {
+		t.Fatalf("Title was serialized when it shouldn't have been")
+	}
+
+	if out.Posts != nil {
+		t.Fatalf("Posts was serialized when it shouldn't have been")
+	}
+
+	if out.CurrentPost != nil {
+		t.Fatalf("CurrentPost was serialized when it shouldn't have been")
+	}
+
+	if out.CurrentPostID != 0 {
+		t.Fatalf("CurrentPostID was serialized when it shouldn't have been")
+	}
+
+	if !out.CreatedAt.IsZero() {
+		t.Fatalf("CreatedAt was serialized when it shouldn't have been")
+	}
+
+	if out.ViewCount != 0 {
+		t.Fatalf("View count was serialized when it shouldn't have been")
+	}
+}
+
 func TestUnmarshal_Times(t *testing.T) {
 	aTime := time.Date(2016, 8, 17, 8, 27, 12, 0, time.UTC)
 

--- a/response.go
+++ b/response.go
@@ -253,13 +253,24 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 
 		annotation := args[0]
 
-		if (annotation == annotationClientID && len(args) != 1) ||
-			(annotation != annotationClientID && len(args) < 2) {
-			er = ErrBadJSONAPIStructTag
-			break
+		switch annotation {
+		case annotationClientID:
+		case annotationIgnore:
+			if len(args) != 1 {
+				er = ErrBadJSONAPIStructTag
+				break
+			}
+		default:
+			if len(args) < 2 {
+				er = ErrBadJSONAPIStructTag
+				break
+			}
 		}
 
-		if annotation == annotationPrimary {
+		if annotation == annotationIgnore {
+			// Do Nothing
+			continue
+		} else if annotation == annotationPrimary {
 			v := fieldValue
 
 			// Deal with PTRS

--- a/response_test.go
+++ b/response_test.go
@@ -342,6 +342,37 @@ func TestWithOmitsEmptyAnnotationOnRelation(t *testing.T) {
 	}
 }
 
+func TestWithIgnoreAnnotation(t *testing.T) {
+	type BlogOptionalPosts struct {
+		ID    int     `jsonapi:"primary,blogs"`
+		Title string  `jsonapi:"attr,title"`
+		Posts []*Post `jsonapi:"-"`
+	}
+
+	blog := &BlogOptionalPosts{ID: 999}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, blog); err != nil {
+		t.Fatal(err)
+	}
+
+	var jsonData map[string]interface{}
+	if err := json.Unmarshal(out.Bytes(), &jsonData); err != nil {
+		t.Fatal(err)
+	}
+	payload := jsonData["data"].(map[string]interface{})
+
+	// Verify posts doesn't appear as a relationship
+	if val, exists := payload["relationships"]; exists {
+		t.Fatalf("Was expecting the data.relationships key/value to have been empty - it was not and had a value of %v", val)
+	}
+	attrs := payload["attributes"].(map[string]interface{})
+	// Verify posts doesn't appear as an attribute
+	if val, exists := attrs["posts"]; exists {
+		t.Fatalf("Was expecting the data.attributes.posts key to not exist - it did and had a value of %v", val)
+	}
+}
+
 func TestWithExtraFieldOnRelation(t *testing.T) {
 	type Book struct {
 		ID     string `jsonapi:"primary,book"`


### PR DESCRIPTION
Previously a struct could never contain a public field that could be ignored by the JSONAPI marshalling/unmarshalling. This made it difficult to provide a struct that only serialized part of the fields. Additionally the JSON (and BSON) marshallers support the '-' as an ignore annotation.

This commit adds the "-" annotation and adds tests and docs updates for this new annotation type.