### PR TITLE
Add NullableRelationship support

### DIFF
--- a/models_test.go
+++ b/models_test.go
@@ -36,12 +36,12 @@ type TimestampModel struct {
 }
 
 type WithNullableAttrs struct {
-	ID          int                     `jsonapi:"primary,with-nullables"`
-	Name        string                  `jsonapi:"attr,name"`
-	IntTime     NullableAttr[time.Time] `jsonapi:"attr,int_time,omitempty"`
-	RFC3339Time NullableAttr[time.Time] `jsonapi:"attr,rfc3339_time,rfc3339,omitempty"`
-	ISO8601Time NullableAttr[time.Time] `jsonapi:"attr,iso8601_time,iso8601,omitempty"`
-	Bool        NullableAttr[bool]      `jsonapi:"attr,bool,omitempty"`
+	ID              int                            `jsonapi:"primary,with-nullables"`
+	Name            string                         `jsonapi:"attr,name"`
+	IntTime         NullableAttr[time.Time]        `jsonapi:"attr,int_time,omitempty"`
+	RFC3339Time     NullableAttr[time.Time]        `jsonapi:"attr,rfc3339_time,rfc3339,omitempty"`
+	ISO8601Time     NullableAttr[time.Time]        `jsonapi:"attr,iso8601_time,iso8601,omitempty"`
+	Bool            NullableAttr[bool]             `jsonapi:"attr,bool,omitempty"`
 	NullableComment NullableRelationship[*Comment] `jsonapi:"relation,nullable_comment,omitempty"`
 }
 

--- a/models_test.go
+++ b/models_test.go
@@ -42,6 +42,7 @@ type WithNullableAttrs struct {
 	RFC3339Time NullableAttr[time.Time] `jsonapi:"attr,rfc3339_time,rfc3339,omitempty"`
 	ISO8601Time NullableAttr[time.Time] `jsonapi:"attr,iso8601_time,iso8601,omitempty"`
 	Bool        NullableAttr[bool]      `jsonapi:"attr,bool,omitempty"`
+	NullableComment NullableRelationship[*Comment] `jsonapi:"relation,nullable_comment,omitempty"`
 }
 
 type Car struct {

--- a/nullable.go
+++ b/nullable.go
@@ -26,6 +26,35 @@ import (
 // Adapted from https://www.jvt.me/posts/2024/01/09/go-json-nullable/
 type NullableAttr[T any] map[bool]T
 
+// NullableRelationship is a generic type, which implements a field that can be one of three states:
+//
+// - relationship is not set in the request
+// - relationship is explicitly set to `null` in the request
+// - relationship is explicitly set to a valid relationship value in the request
+//
+// NullableRelationship is intended to be used with JSON marshalling and unmarshalling.
+// This is generally useful for PATCH requests, where relationships with zero
+// values are intentionally not marshaled into the request payload so that
+// existing attribute values are not overwritten.
+//
+// Internal implementation details:
+//
+// - map[true]T means a value was provided
+// - map[false]T means an explicit null was provided
+// - nil or zero map means the field was not provided
+//
+// If the relationship is expected to be optional, add the `omitempty` JSON tags. Do NOT use `*NullableRelationship`!
+//
+// Slice types are not currently supported for NullableRelationships as the nullable nature can be expressed via empty array
+// `polyrelation` JSON tags are NOT currently supported.
+//
+// NullableRelationships must have an inner type of pointer:
+//
+// - NullableRelationship[*Comment] - valid
+// - NullableRelationship[[]*Comment] - invalid
+// - NullableRelationship[Comment] - invalid
+type NullableRelationship[T any] map[bool]T
+
 // NewNullableAttrWithValue is a convenience helper to allow constructing a
 // NullableAttr with a given value, for instance to construct a field inside a
 // struct without introducing an intermediate variable.
@@ -85,5 +114,67 @@ func (t NullableAttr[T]) IsSpecified() bool {
 
 // SetUnspecified sets the value to be absent from the serialized payload
 func (t *NullableAttr[T]) SetUnspecified() {
+	*t = map[bool]T{}
+}
+
+// NewNullableAttrWithValue is a convenience helper to allow constructing a
+// NullableAttr with a given value, for instance to construct a field inside a
+// struct without introducing an intermediate variable.
+func NewNullableRelationshipWithValue[T any](t T) NullableRelationship[T] {
+	var n NullableRelationship[T]
+	n.Set(t)
+	return n
+}
+
+// NewNullNullableAttr is a convenience helper to allow constructing a NullableAttr with
+// an explicit `null`, for instance to construct a field inside a struct
+// without introducing an intermediate variable
+func NewNullNullableRelationship[T any]() NullableRelationship[T] {
+	var n NullableRelationship[T]
+	n.SetNull()
+	return n
+}
+
+// Get retrieves the underlying value, if present, and returns an error if the value was not present
+func (t NullableRelationship[T]) Get() (T, error) {
+	var empty T
+	if t.IsNull() {
+		return empty, errors.New("value is null")
+	}
+	if !t.IsSpecified() {
+		return empty, errors.New("value is not specified")
+	}
+	return t[true], nil
+}
+
+// Set sets the underlying value to a given value
+func (t *NullableRelationship[T]) Set(value T) {
+	*t = map[bool]T{true: value}
+}
+
+// Set sets the underlying value to a given value
+func (t *NullableRelationship[T]) SetInterface(value interface{}) {
+	t.Set(value.(T))
+}
+
+// IsNull indicates whether the field was sent, and had a value of `null`
+func (t NullableRelationship[T]) IsNull() bool {
+	_, foundNull := t[false]
+	return foundNull
+}
+
+// SetNull sets the value to an explicit `null`
+func (t *NullableRelationship[T]) SetNull() {
+	var empty T
+	*t = map[bool]T{false: empty}
+}
+
+// IsSpecified indicates whether the field was sent
+func (t NullableRelationship[T]) IsSpecified() bool {
+	return len(t) != 0
+}
+
+// SetUnspecified sets the value to be absent from the serialized payload
+func (t *NullableRelationship[T]) SetUnspecified() {
 	*t = map[bool]T{}
 }

--- a/nullable.go
+++ b/nullable.go
@@ -152,7 +152,8 @@ func (t *NullableRelationship[T]) Set(value T) {
 	*t = map[bool]T{true: value}
 }
 
-// Set sets the underlying value to a given value
+// SetInterface sets the underlying value from an empty interface,
+// performing a type assertion to T.
 func (t *NullableRelationship[T]) SetInterface(value interface{}) {
 	t.Set(value.(T))
 }

--- a/nullable.go
+++ b/nullable.go
@@ -126,7 +126,7 @@ func NewNullableRelationshipWithValue[T any](t T) NullableRelationship[T] {
 	return n
 }
 
-// NewNullNullableAttr is a convenience helper to allow constructing a NullableAttr with
+// NewNullNullableRelationship is a convenience helper to allow constructing a NullableRelationship with
 // an explicit `null`, for instance to construct a field inside a struct
 // without introducing an intermediate variable
 func NewNullNullableRelationship[T any]() NullableRelationship[T] {

--- a/nullable.go
+++ b/nullable.go
@@ -117,8 +117,8 @@ func (t *NullableAttr[T]) SetUnspecified() {
 	*t = map[bool]T{}
 }
 
-// NewNullableAttrWithValue is a convenience helper to allow constructing a
-// NullableAttr with a given value, for instance to construct a field inside a
+// NewNullableRelationshipWithValue is a convenience helper to allow constructing a
+// NullableRelationship with a given value, for instance to construct a field inside a
 // struct without introducing an intermediate variable.
 func NewNullableRelationshipWithValue[T any](t T) NullableRelationship[T] {
 	var n NullableRelationship[T]

--- a/response.go
+++ b/response.go
@@ -253,7 +253,7 @@ func visitModelNodeAttribute(args []string, node *Node, fieldValue reflect.Value
 		node.Attributes = make(map[string]interface{})
 	}
 
-	// Handle Nullable[T]
+	// Handle NullableAttr[T]
 	if strings.HasPrefix(fieldValue.Type().Name(), "NullableAttr[") {
 		// handle unspecified
 		if fieldValue.IsNil() {
@@ -390,6 +390,27 @@ func visitModelNodeRelation(model any, annotation string, args []string, node *N
 		omitEmpty = args[2] == annotationOmitEmpty
 	}
 
+	if node.Relationships == nil {
+		node.Relationships = make(map[string]interface{})
+	}
+
+	// Handle NullableRelationship[T]
+	if strings.HasPrefix(fieldValue.Type().Name(), "NullableRelationship[") {
+
+		if fieldValue.MapIndex(reflect.ValueOf(false)).IsValid() {
+			innerTypeIsSlice := fieldValue.MapIndex(reflect.ValueOf(false)).Type().Kind() == reflect.Slice
+			// handle explicit null
+			if innerTypeIsSlice {
+				node.Relationships[args[1]] = json.RawMessage("[]")
+			} else {
+				node.Relationships[args[1]] = json.RawMessage("{\"data\":null}")
+			}
+		} else if fieldValue.MapIndex(reflect.ValueOf(true)).IsValid() {
+			// handle value
+			fieldValue = fieldValue.MapIndex(reflect.ValueOf(true))
+		}
+	}
+
 	isSlice := fieldValue.Type().Kind() == reflect.Slice
 	if omitEmpty &&
 		(isSlice && fieldValue.Len() < 1 ||
@@ -452,10 +473,6 @@ func visitModelNodeRelation(model any, annotation string, args []string, node *N
 
 			fieldValue = reflect.ValueOf(collection)
 		}
-	}
-
-	if node.Relationships == nil {
-		node.Relationships = make(map[string]interface{})
 	}
 
 	var relLinks *Links

--- a/response.go
+++ b/response.go
@@ -405,6 +405,7 @@ func visitModelNodeRelation(model any, annotation string, args []string, node *N
 			} else {
 				node.Relationships[args[1]] = json.RawMessage("{\"data\":null}")
 			}
+			return nil
 		} else if fieldValue.MapIndex(reflect.ValueOf(true)).IsValid() {
 			// handle value
 			fieldValue = fieldValue.MapIndex(reflect.ValueOf(true))


### PR DESCRIPTION
http://jsonapi.org/format/#document-resource-object-relationships
http://jsonapi.org/format/#document-resource-object-linkage
Relationships can have a data node set to null (e.g. to disassociate the relationship)

The NullableRelationship type allows this data to be serialized/de-serialized. When serialized, a NullableRelationship with an explicit null will serialize to the appropriate "null" type. Either '"data": null' or '[]'.

Supports slice and regular reference types for serialization, and regular reference types for de-serialization.
The reason to not support slices for de-serialization is we need to decide how to handle the zero type for a NullableRelationship[[]*...] slice. Since we aren't using this and can emulate the nulling behavior by omitting omit-empty we decided to ignore this case for now.

Related commits:
[1st Commit](https://github.com/google/jsonapi/commit/ec17fee03a4347bde17925eea81dcaf727afd8a4#diff-6b94feb58536b61f1aaf93471d52ee58748d9252f08e12cd9cce2feb44c49691)
[2nd Commit](https://github.com/google/jsonapi/commit/4dedb19ba93f0c4d92a446ad8759ff2586b0659b#diff-0c3b8d00294016bf1b71ccc52490349defd0dc920d069460f7b81cf27bdbfbff)

[Reference PR](https://github.com/hashicorp/jsonapi/pull/23)
